### PR TITLE
feat: SQLAlchemy models and database setup (#21-#28)

### DIFF
--- a/apps/api/src/db/__init__.py
+++ b/apps/api/src/db/__init__.py
@@ -1,0 +1,6 @@
+"""Database module."""
+
+from src.db.base import Base
+from src.db.database import get_db
+
+__all__ = ["Base", "get_db"]

--- a/apps/api/src/db/base.py
+++ b/apps/api/src/db/base.py
@@ -1,0 +1,28 @@
+"""SQLAlchemy declarative base."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for all models."""
+
+    pass
+
+
+class TimestampMixin:
+    """Mixin for created_at and updated_at timestamps."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/apps/api/src/db/database.py
+++ b/apps/api/src/db/database.py
@@ -1,0 +1,32 @@
+"""Database connection and session management."""
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.config import get_settings
+
+settings = get_settings()
+
+engine = create_async_engine(
+    settings.database_url,
+    echo=settings.debug,
+    pool_pre_ping=True,
+    pool_size=5,
+    max_overflow=10,
+)
+
+async_session_factory = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Dependency for getting async database sessions."""
+    async with async_session_factory() as session:
+        try:
+            yield session
+        finally:
+            await session.close()

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -1,0 +1,19 @@
+"""SQLAlchemy models."""
+
+from src.models.card import Card
+from src.models.deck import Deck
+from src.models.meta_snapshot import MetaSnapshot
+from src.models.set import Set
+from src.models.tournament import Tournament
+from src.models.tournament_placement import TournamentPlacement
+from src.models.user import User
+
+__all__ = [
+    "Card",
+    "Deck",
+    "MetaSnapshot",
+    "Set",
+    "Tournament",
+    "TournamentPlacement",
+    "User",
+]

--- a/apps/api/src/models/card.py
+++ b/apps/api/src/models/card.py
@@ -1,0 +1,75 @@
+"""Card model for Pokemon TCG cards."""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.set import Set
+
+
+class Card(Base, TimestampMixin):
+    """Pokemon TCG card."""
+
+    __tablename__ = "cards"
+
+    # Primary key (TCGdex ID, e.g., "sv4-6")
+    id: Mapped[str] = mapped_column(String(50), primary_key=True)
+
+    # Basic info
+    local_id: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    japanese_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Card type
+    supertype: Mapped[str] = mapped_column(
+        String(50), nullable=False, index=True
+    )  # Pokemon, Trainer, Energy
+    subtypes: Mapped[list[str] | None] = mapped_column(
+        ARRAY(String(50)), nullable=True
+    )  # Stage 1, ex, V, etc.
+    types: Mapped[list[str] | None] = mapped_column(
+        ARRAY(String(50)), nullable=True
+    )  # Fire, Water, etc.
+
+    # Pokemon stats
+    hp: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    stage: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    evolves_from: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    evolves_to: Mapped[list[str] | None] = mapped_column(
+        ARRAY(String(255)), nullable=True
+    )
+
+    # Game mechanics (JSON for flexibility)
+    attacks: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    abilities: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    weaknesses: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    resistances: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    retreat_cost: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rules: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
+
+    # Set info
+    set_id: Mapped[str] = mapped_column(
+        String(50), ForeignKey("sets.id"), nullable=False, index=True
+    )
+    rarity: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    number: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # Images
+    image_small: Mapped[str | None] = mapped_column(Text, nullable=True)
+    image_large: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Legality
+    regulation_mark: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    legalities: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Semantic search embedding (pgvector, 1536 dimensions for OpenAI ada-002)
+    # Note: Requires pgvector extension. Column added via migration.
+    # embedding: Mapped[list[float] | None] = mapped_column(Vector(1536), nullable=True)
+
+    # Relationships
+    set: Mapped["Set"] = relationship("Set", back_populates="cards")

--- a/apps/api/src/models/deck.py
+++ b/apps/api/src/models/deck.py
@@ -1,0 +1,55 @@
+"""Deck model for user deck storage."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.tournament_placement import TournamentPlacement
+    from src.models.user import User
+
+
+class Deck(Base, TimestampMixin):
+    """User-created deck."""
+
+    __tablename__ = "decks"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Owner
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Deck info
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Cards (JSON array: [{"card_id": "sv4-6", "quantity": 4}, ...])
+    cards: Mapped[list[dict]] = mapped_column(JSONB, nullable=False, default=[])
+
+    # Format and archetype
+    format: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="standard"
+    )  # standard, expanded
+    archetype: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, index=True
+    )
+
+    # Sharing
+    is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    share_code: Mapped[str | None] = mapped_column(
+        String(20), unique=True, nullable=True
+    )
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="decks")
+    tournament_placements: Mapped[list["TournamentPlacement"]] = relationship(
+        "TournamentPlacement", back_populates="deck"
+    )

--- a/apps/api/src/models/meta_snapshot.py
+++ b/apps/api/src/models/meta_snapshot.py
@@ -1,0 +1,50 @@
+"""MetaSnapshot model for computed meta data."""
+
+from datetime import date as date_type
+from uuid import UUID
+
+from sqlalchemy import Date, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.db.base import Base, TimestampMixin
+
+
+class MetaSnapshot(Base, TimestampMixin):
+    """Computed meta snapshot for a specific date/region/format."""
+
+    __tablename__ = "meta_snapshots"
+
+    # Unique constraint on snapshot dimensions
+    __table_args__ = (
+        UniqueConstraint(
+            "snapshot_date", "region", "format", "best_of", name="uq_meta_snapshot"
+        ),
+    )
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Snapshot dimensions
+    snapshot_date: Mapped[date_type] = mapped_column(Date, nullable=False, index=True)
+    region: Mapped[str | None] = mapped_column(
+        String(20), nullable=True, index=True
+    )  # null = global
+    format: Mapped[str] = mapped_column(
+        String(50), nullable=False, index=True
+    )  # standard, expanded
+    best_of: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=3
+    )  # 1 for Japan, 3 for international
+
+    # Archetype breakdown (JSON: {"Charizard ex": 0.15, "Lugia VSTAR": 0.12, ...})
+    archetype_shares: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    # Card usage rates (JSON: {"sv4-6": {"inclusion_rate": 0.85, ...}, ...})
+    card_usage: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Sample info
+    sample_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    tournaments_included: Mapped[list[str] | None] = mapped_column(
+        ARRAY(String(50)), nullable=True
+    )

--- a/apps/api/src/models/set.py
+++ b/apps/api/src/models/set.py
@@ -1,0 +1,41 @@
+"""Set model for Pokemon TCG card sets."""
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Date, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.card import Card
+
+
+class Set(Base, TimestampMixin):
+    """Pokemon TCG card set."""
+
+    __tablename__ = "sets"
+
+    # Primary key (TCGdex ID, e.g., "sv4")
+    id: Mapped[str] = mapped_column(String(50), primary_key=True)
+
+    # Basic info
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    series: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # Release info
+    release_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    release_date_jp: Mapped[date | None] = mapped_column(Date, nullable=True)
+    card_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Images
+    logo_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    symbol_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Legalities (JSON: {"standard": "Legal", "expanded": "Legal"})
+    legalities: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Relationships
+    cards: Mapped[list["Card"]] = relationship("Card", back_populates="set")

--- a/apps/api/src/models/tournament.py
+++ b/apps/api/src/models/tournament.py
@@ -1,0 +1,52 @@
+"""Tournament model for meta tracking."""
+
+from datetime import date as date_type
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Date, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.tournament_placement import TournamentPlacement
+
+
+class Tournament(Base, TimestampMixin):
+    """Pokemon TCG tournament."""
+
+    __tablename__ = "tournaments"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Basic info
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    date: Mapped[date_type] = mapped_column(Date, nullable=False, index=True)
+
+    # Location/region (NA, EU, JP, LATAM, OCE)
+    region: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    country: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # Format
+    format: Mapped[str] = mapped_column(
+        String(50), nullable=False, index=True
+    )  # standard, expanded
+    best_of: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=3
+    )  # 1 for Japan, 3 for international
+
+    # Stats
+    participant_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Source
+    source: Mapped[str | None] = mapped_column(
+        String(100), nullable=True
+    )  # limitless, rk9, etc.
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Relationships
+    placements: Mapped[list["TournamentPlacement"]] = relationship(
+        "TournamentPlacement", back_populates="tournament", cascade="all, delete-orphan"
+    )

--- a/apps/api/src/models/tournament_placement.py
+++ b/apps/api/src/models/tournament_placement.py
@@ -1,0 +1,52 @@
+"""TournamentPlacement model for tournament results."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.deck import Deck
+    from src.models.tournament import Tournament
+
+
+class TournamentPlacement(Base, TimestampMixin):
+    """A deck's placement in a tournament."""
+
+    __tablename__ = "tournament_placements"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Tournament reference
+    tournament_id: Mapped[UUID] = mapped_column(
+        ForeignKey("tournaments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Deck reference (nullable - not all placements have full deck lists)
+    deck_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("decks.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Placement info
+    placement: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    player_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Archetype (even if no full deck list)
+    archetype: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # Deck list (JSON if available, for tournament-specific lists)
+    decklist: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    decklist_source: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Relationships
+    tournament: Mapped["Tournament"] = relationship(
+        "Tournament", back_populates="placements"
+    )
+    deck: Mapped["Deck | None"] = relationship(
+        "Deck", back_populates="tournament_placements"
+    )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -1,0 +1,40 @@
+"""User model for authentication."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.deck import Deck
+
+
+class User(Base, TimestampMixin):
+    """Application user (linked to Firebase Auth)."""
+
+    __tablename__ = "users"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Firebase Auth
+    firebase_uid: Mapped[str] = mapped_column(
+        String(128), unique=True, nullable=False, index=True
+    )
+
+    # Profile
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Preferences (JSON: theme, default_format, etc.)
+    preferences: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default={})
+
+    # Relationships
+    decks: Mapped[list["Deck"]] = relationship(
+        "Deck", back_populates="user", cascade="all, delete-orphan"
+    )

--- a/apps/api/tests/test_models.py
+++ b/apps/api/tests/test_models.py
@@ -1,0 +1,111 @@
+"""Tests for SQLAlchemy models."""
+
+from datetime import date
+from uuid import uuid4
+
+from src.models import (
+    Card,
+    Deck,
+    MetaSnapshot,
+    Set,
+    Tournament,
+    TournamentPlacement,
+    User,
+)
+
+
+def test_set_model() -> None:
+    """Test Set model instantiation."""
+    card_set = Set(
+        id="sv4",
+        name="Paradox Rift",
+        series="Scarlet & Violet",
+        card_count=182,
+    )
+    assert card_set.id == "sv4"
+    assert card_set.name == "Paradox Rift"
+
+
+def test_card_model() -> None:
+    """Test Card model instantiation."""
+    card = Card(
+        id="sv4-6",
+        local_id="6",
+        name="Charizard ex",
+        supertype="Pokemon",
+        subtypes=["Stage 2", "ex"],
+        types=["Fire"],
+        hp=330,
+        set_id="sv4",
+    )
+    assert card.id == "sv4-6"
+    assert card.name == "Charizard ex"
+    assert card.hp == 330
+
+
+def test_user_model() -> None:
+    """Test User model instantiation."""
+    user = User(
+        id=uuid4(),
+        firebase_uid="firebase-123",
+        email="trainer@example.com",
+        display_name="Ash Ketchum",
+    )
+    assert user.email == "trainer@example.com"
+
+
+def test_deck_model() -> None:
+    """Test Deck model instantiation."""
+    deck = Deck(
+        id=uuid4(),
+        user_id=uuid4(),
+        name="Charizard ex Deck",
+        cards=[{"card_id": "sv4-6", "quantity": 3}],
+        format="standard",
+        archetype="Charizard ex",
+    )
+    assert deck.name == "Charizard ex Deck"
+    assert len(deck.cards) == 1
+
+
+def test_tournament_model() -> None:
+    """Test Tournament model instantiation."""
+    tournament = Tournament(
+        id=uuid4(),
+        name="LAIC 2024",
+        date=date(2024, 11, 15),
+        region="NA",
+        format="standard",
+        best_of=3,
+        participant_count=1200,
+    )
+    assert tournament.name == "LAIC 2024"
+    assert tournament.best_of == 3
+
+
+def test_tournament_placement_model() -> None:
+    """Test TournamentPlacement model instantiation."""
+    placement = TournamentPlacement(
+        id=uuid4(),
+        tournament_id=uuid4(),
+        placement=1,
+        player_name="Winner",
+        archetype="Charizard ex",
+    )
+    assert placement.placement == 1
+    assert placement.archetype == "Charizard ex"
+
+
+def test_meta_snapshot_model() -> None:
+    """Test MetaSnapshot model instantiation."""
+    snapshot = MetaSnapshot(
+        id=uuid4(),
+        snapshot_date=date(2024, 11, 20),
+        region="NA",
+        format="standard",
+        best_of=3,
+        archetype_shares={"Charizard ex": 0.15, "Lugia VSTAR": 0.12},
+        sample_size=500,
+    )
+    assert snapshot.format == "standard"
+    assert snapshot.archetype_shares["Charizard ex"] == 0.15


### PR DESCRIPTION
## Summary
Complete SQLAlchemy model layer with all database entities for TrainerLab.

## Issues Addressed
- #21: Create SQLAlchemy base and database.py connection setup
- #22: Create Card SQLAlchemy model
- #23: Create Set SQLAlchemy model
- #24: Create User SQLAlchemy model
- #25: Create Deck SQLAlchemy model
- #26: Create Tournament SQLAlchemy model
- #27: Create TournamentPlacement SQLAlchemy model
- #28: Create MetaSnapshot SQLAlchemy model

## Changes

### Database Setup (#21)
- `src/db/base.py` - Declarative base with timestamp mixin
- `src/db/database.py` - Async engine, session factory, `get_db` dependency
- Connection pooling (5 pool size, 10 max overflow)

### Models

| Model | Key Fields |
|-------|------------|
| **Set** (#23) | id (TCGdex), name, series, release_date, legalities |
| **Card** (#22) | id (TCGdex), name, supertype, types[], attacks JSON, set_id FK |
| **User** (#24) | id (UUID), firebase_uid, email, preferences JSON |
| **Deck** (#25) | id (UUID), user_id FK, cards JSON, format, archetype |
| **Tournament** (#26) | id (UUID), name, date, region, format, best_of |
| **TournamentPlacement** (#27) | tournament_id FK, deck_id FK, placement, archetype |
| **MetaSnapshot** (#28) | snapshot_date, region, format, archetype_shares JSON |

### Relationships
- Set → Cards (one-to-many)
- User → Decks (one-to-many, cascade delete)
- Tournament → Placements (one-to-many, cascade delete)
- Deck → Placements (one-to-many)

## Testing
- [x] `uv run pytest -v` - 8 tests pass
- [x] `uv run ruff check` - passes
- [x] All pre-commit hooks pass

## Notes
- Card embedding column commented out (requires pgvector extension, added in migration)
- MetaSnapshot has unique constraint on (snapshot_date, region, format, best_of)
- JSON columns use PostgreSQL JSONB for efficient querying

Closes #21, closes #22, closes #23, closes #24, closes #25, closes #26, closes #27, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)