### PR TITLE
feat: add GET /api/v1/cards endpoint with pagination

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.config import get_settings
-from src.routers import health_router
+from src.routers import cards_router, health_router
 
 settings = get_settings()
 
@@ -39,4 +39,5 @@ app.add_middleware(
 )
 
 # Include routers
+app.include_router(cards_router)
 app.include_router(health_router)

--- a/apps/api/src/routers/__init__.py
+++ b/apps/api/src/routers/__init__.py
@@ -1,5 +1,6 @@
 """API routers."""
 
+from src.routers.cards import router as cards_router
 from src.routers.health import router as health_router
 
-__all__ = ["health_router"]
+__all__ = ["cards_router", "health_router"]

--- a/apps/api/src/routers/cards.py
+++ b/apps/api/src/routers/cards.py
@@ -1,0 +1,38 @@
+"""Card endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.database import get_db
+from src.schemas import CardSummaryResponse, PaginatedResponse
+from src.services.card_service import CardService, SortField, SortOrder
+
+router = APIRouter(prefix="/api/v1/cards", tags=["cards"])
+
+
+@router.get("")
+async def list_cards(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    limit: Annotated[
+        int, Query(ge=1, le=100, description="Items per page (max 100)")
+    ] = 20,
+    sort_by: Annotated[
+        SortField, Query(description="Field to sort by")
+    ] = SortField.NAME,
+    sort_order: Annotated[SortOrder, Query(description="Sort order")] = SortOrder.ASC,
+) -> PaginatedResponse[CardSummaryResponse]:
+    """List all cards with pagination.
+
+    Returns a paginated list of card summaries. Default page size is 20,
+    maximum is 100. Results can be sorted by name, set, or date.
+    """
+    service = CardService(db)
+    return await service.list_cards(
+        page=page,
+        limit=limit,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )

--- a/apps/api/src/services/card_service.py
+++ b/apps/api/src/services/card_service.py
@@ -1,0 +1,97 @@
+"""Card query service for database operations."""
+
+from enum import Enum
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.card import Card
+from src.schemas import CardSummaryResponse, PaginatedResponse
+
+
+class SortField(str, Enum):
+    """Allowed sort fields for cards."""
+
+    NAME = "name"
+    SET = "set_id"
+    DATE = "created_at"
+
+
+class SortOrder(str, Enum):
+    """Sort order options."""
+
+    ASC = "asc"
+    DESC = "desc"
+
+
+class CardService:
+    """Service for querying cards from the database."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_cards(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 20,
+        sort_by: SortField = SortField.NAME,
+        sort_order: SortOrder = SortOrder.ASC,
+    ) -> PaginatedResponse[CardSummaryResponse]:
+        """List cards with pagination and sorting.
+
+        Args:
+            page: Page number (1-indexed)
+            limit: Items per page (max 100)
+            sort_by: Field to sort by
+            sort_order: Sort direction
+
+        Returns:
+            Paginated response with card summaries
+        """
+        # Build base query
+        query = select(Card)
+
+        # Apply sorting
+        query = self._apply_sorting(query, sort_by, sort_order)
+
+        # Get total count
+        total = await self._get_total_count(query)
+
+        # Apply pagination
+        offset = (page - 1) * limit
+        query = query.offset(offset).limit(limit)
+
+        # Execute query
+        result = await self.session.execute(query)
+        cards = result.scalars().all()
+
+        # Build response
+        items = [CardSummaryResponse.model_validate(card) for card in cards]
+
+        return PaginatedResponse[CardSummaryResponse](
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+            has_next=page * limit < total,
+            has_prev=page > 1,
+        )
+
+    def _apply_sorting(
+        self,
+        query: Select[tuple[Card]],
+        sort_by: SortField,
+        sort_order: SortOrder,
+    ) -> Select[tuple[Card]]:
+        """Apply sorting to the query."""
+        column = getattr(Card, sort_by.value)
+        if sort_order == SortOrder.DESC:
+            column = column.desc()
+        return query.order_by(column)
+
+    async def _get_total_count(self, query: Select[tuple[Card]]) -> int:
+        """Get total count for a query (without pagination)."""
+        count_query = select(func.count()).select_from(query.subquery())
+        result = await self.session.execute(count_query)
+        return result.scalar() or 0

--- a/apps/api/tests/test_cards.py
+++ b/apps/api/tests/test_cards.py
@@ -1,0 +1,191 @@
+"""Tests for card endpoints and service."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.models.card import Card
+from src.schemas import PaginatedResponse
+from src.services.card_service import CardService, SortField, SortOrder
+
+
+class TestCardService:
+    """Tests for CardService."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        """Create a mock async session."""
+        session = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def service(self, mock_session: AsyncMock) -> CardService:
+        """Create a CardService with mock session."""
+        return CardService(mock_session)
+
+    @pytest.fixture
+    def sample_card(self) -> MagicMock:
+        """Create a sample card mock."""
+        card = MagicMock(spec=Card)
+        card.id = "sv4-6"
+        card.name = "Pikachu"
+        card.supertype = "Pokemon"
+        card.types = ["Lightning"]
+        card.set_id = "sv4"
+        card.rarity = "Common"
+        card.image_small = "https://example.com/pikachu.png"
+        return card
+
+    @pytest.mark.asyncio
+    async def test_list_cards_empty(self, service: CardService) -> None:
+        """Test listing cards when no cards exist."""
+        # Mock empty results
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        service.session.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=0)),  # count query
+            mock_result,  # main query
+        ]
+
+        result = await service.list_cards()
+
+        assert isinstance(result, PaginatedResponse)
+        assert result.items == []
+        assert result.total == 0
+        assert result.page == 1
+        assert result.limit == 20
+        assert result.has_next is False
+        assert result.has_prev is False
+
+    @pytest.mark.asyncio
+    async def test_list_cards_with_results(
+        self, service: CardService, sample_card: MagicMock
+    ) -> None:
+        """Test listing cards with results."""
+        # Mock results with one card
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_card]
+        service.session.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=1)),  # count query
+            mock_result,  # main query
+        ]
+
+        result = await service.list_cards()
+
+        assert len(result.items) == 1
+        assert result.items[0].id == "sv4-6"
+        assert result.items[0].name == "Pikachu"
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_list_cards_pagination(
+        self, service: CardService, sample_card: MagicMock
+    ) -> None:
+        """Test pagination calculations."""
+        # Mock results
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_card]
+        service.session.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=100)),  # total count
+            mock_result,
+        ]
+
+        result = await service.list_cards(page=2, limit=20)
+
+        assert result.page == 2
+        assert result.limit == 20
+        assert result.total == 100
+        assert result.has_next is True
+        assert result.has_prev is True
+        assert result.total_pages == 5
+
+    @pytest.mark.asyncio
+    async def test_list_cards_last_page(
+        self, service: CardService, sample_card: MagicMock
+    ) -> None:
+        """Test last page has no next."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_card]
+        service.session.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=41)),  # 41 total, 3 pages
+            mock_result,
+        ]
+
+        result = await service.list_cards(page=3, limit=20)
+
+        assert result.has_next is False
+        assert result.has_prev is True
+
+
+class TestSortEnums:
+    """Tests for sort enums."""
+
+    def test_sort_field_values(self) -> None:
+        """Test SortField enum values."""
+        assert SortField.NAME.value == "name"
+        assert SortField.SET.value == "set_id"
+        assert SortField.DATE.value == "created_at"
+
+    def test_sort_order_values(self) -> None:
+        """Test SortOrder enum values."""
+        assert SortOrder.ASC.value == "asc"
+        assert SortOrder.DESC.value == "desc"
+
+
+class TestCardsEndpoint:
+    """Tests for cards API endpoint."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database session."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def client(self, mock_db: AsyncMock) -> TestClient:
+        """Create test client with mocked database."""
+        from src.db.database import get_db
+
+        async def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+    def test_list_cards_endpoint_exists(
+        self, client: TestClient, mock_db: AsyncMock
+    ) -> None:
+        """Test that the cards endpoint exists."""
+        # Mock empty results
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=0)),  # count query
+            mock_result,  # main query
+        ]
+
+        response = client.get("/api/v1/cards")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["page"] == 1
+        assert data["limit"] == 20
+
+    def test_list_cards_invalid_page(self, client: TestClient) -> None:
+        """Test that page < 1 returns 422."""
+        response = client.get("/api/v1/cards?page=0")
+        assert response.status_code == 422
+
+    def test_list_cards_invalid_limit(self, client: TestClient) -> None:
+        """Test that limit > 100 returns 422."""
+        response = client.get("/api/v1/cards?limit=101")
+        assert response.status_code == 422
+
+    def test_list_cards_invalid_limit_zero(self, client: TestClient) -> None:
+        """Test that limit < 1 returns 422."""
+        response = client.get("/api/v1/cards?limit=0")
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add CardService for database queries with pagination and sorting
- Add cards router with list endpoint
- Support sorting by name, set_id, or created_at
- Default page size 20, max 100
- Return PaginatedResponse[CardSummaryResponse]

## Test plan
- [x] Unit tests for CardService
- [x] Unit tests for endpoint validation
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #43