### PR TITLE
feat: add supertype filter to GET /api/v1/cards

### DIFF
--- a/apps/api/src/routers/cards.py
+++ b/apps/api/src/routers/cards.py
@@ -26,6 +26,10 @@ async def list_cards(
     q: Annotated[
         str | None, Query(description="Search query (searches card name)")
     ] = None,
+    supertype: Annotated[
+        list[str] | None,
+        Query(description="Filter by supertype (Pokemon, Trainer, Energy)"),
+    ] = None,
 ) -> PaginatedResponse[CardSummaryResponse]:
     """List all cards with pagination.
 
@@ -33,6 +37,8 @@ async def list_cards(
     maximum is 100. Results can be sorted by name, set, or date.
 
     Use the `q` parameter for case-insensitive partial matching on card names.
+    Use the `supertype` parameter to filter by card type. Multiple values can
+    be provided: ?supertype=Pokemon&supertype=Trainer
     """
     service = CardService(db)
     return await service.list_cards(
@@ -41,4 +47,5 @@ async def list_cards(
         sort_by=sort_by,
         sort_order=sort_order,
         q=q,
+        supertype=supertype,
     )

--- a/apps/api/src/services/card_service.py
+++ b/apps/api/src/services/card_service.py
@@ -38,6 +38,7 @@ class CardService:
         sort_by: SortField = SortField.NAME,
         sort_order: SortOrder = SortOrder.ASC,
         q: str | None = None,
+        supertype: list[str] | None = None,
     ) -> PaginatedResponse[CardSummaryResponse]:
         """List cards with pagination and sorting.
 
@@ -47,6 +48,7 @@ class CardService:
             sort_by: Field to sort by
             sort_order: Sort direction
             q: Optional text search query (searches name field)
+            supertype: Filter by supertype(s) (Pokemon, Trainer, Energy)
 
         Returns:
             Paginated response with card summaries
@@ -57,6 +59,10 @@ class CardService:
         # Apply text search filter
         if q:
             query = query.where(Card.name.ilike(f"%{q}%"))
+
+        # Apply supertype filter
+        if supertype:
+            query = query.where(Card.supertype.in_(supertype))
 
         # Apply sorting
         query = self._apply_sorting(query, sort_by, sort_order)

--- a/apps/api/tests/test_cards.py
+++ b/apps/api/tests/test_cards.py
@@ -150,6 +150,39 @@ class TestCardService:
         assert result.items == []
         assert result.total == 0
 
+    @pytest.mark.asyncio
+    async def test_list_cards_with_supertype_filter(
+        self, service: CardService, sample_card: MagicMock
+    ) -> None:
+        """Test filtering by single supertype."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_card]
+        service.session.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=1)),
+            mock_result,
+        ]
+
+        result = await service.list_cards(supertype=["Pokemon"])
+
+        assert len(result.items) == 1
+        assert result.items[0].supertype == "Pokemon"
+
+    @pytest.mark.asyncio
+    async def test_list_cards_with_multiple_supertypes(
+        self, service: CardService, sample_card: MagicMock
+    ) -> None:
+        """Test filtering by multiple supertypes."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_card]
+        service.session.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=1)),
+            mock_result,
+        ]
+
+        result = await service.list_cards(supertype=["Pokemon", "Trainer"])
+
+        assert len(result.items) == 1
+
 
 class TestSortEnums:
     """Tests for sort enums."""
@@ -238,3 +271,33 @@ class TestCardsEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["items"] == []
+
+    def test_list_cards_with_supertype_filter(
+        self, client: TestClient, mock_db: AsyncMock
+    ) -> None:
+        """Test that supertype filter parameter is accepted."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=0)),
+            mock_result,
+        ]
+
+        response = client.get("/api/v1/cards?supertype=Pokemon")
+
+        assert response.status_code == 200
+
+    def test_list_cards_with_multiple_supertypes(
+        self, client: TestClient, mock_db: AsyncMock
+    ) -> None:
+        """Test that multiple supertype values are accepted."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute.side_effect = [
+            MagicMock(scalar=MagicMock(return_value=0)),
+            mock_result,
+        ]
+
+        response = client.get("/api/v1/cards?supertype=Pokemon&supertype=Trainer")
+
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Add ?supertype= query parameter
- Filter by Pokemon, Trainer, or Energy
- Support multiple values: ?supertype=Pokemon&supertype=Trainer

## Test plan
- [x] Unit tests for supertype filtering in CardService
- [x] Endpoint tests for single and multiple supertype values
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #45