### PR TITLE
feat: implement Phase 2 frontend for card search

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "assets.tcgdex.net",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,10 @@
     "clean": "rm -rf .next .turbo node_modules"
   },
   "dependencies": {
+    "@trainerlab/shared-types": "workspace:*",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.0",
+    "@tanstack/react-query": "^5.90.20",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.460.0",

--- a/apps/web/src/app/cards/[id]/page.tsx
+++ b/apps/web/src/app/cards/[id]/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useCard } from "@/hooks/useCards";
+import { CardDetail } from "@/components/cards";
+import { Button } from "@/components/ui/button";
+
+interface CardDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+function CardDetailSkeleton() {
+  return (
+    <div className="flex flex-col md:flex-row gap-8 animate-pulse">
+      <div
+        className="bg-muted rounded-lg flex-shrink-0 mx-auto md:mx-0"
+        style={{ width: 320, height: 448 }}
+      />
+      <div className="flex-1 space-y-4">
+        <div className="h-8 bg-muted rounded w-1/2" />
+        <div className="h-4 bg-muted rounded w-1/3" />
+        <div className="flex gap-2">
+          <div className="h-6 bg-muted rounded w-20" />
+          <div className="h-6 bg-muted rounded w-20" />
+        </div>
+        <div className="h-24 bg-muted rounded" />
+        <div className="h-24 bg-muted rounded" />
+      </div>
+    </div>
+  );
+}
+
+export default function CardDetailPage({ params }: CardDetailPageProps) {
+  const { id } = use(params);
+  const { data: card, isLoading, isError, error } = useCard(id);
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      {/* Back Button */}
+      <Button variant="ghost" asChild className="mb-6">
+        <Link href="/cards">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Cards
+        </Link>
+      </Button>
+
+      {/* Loading State */}
+      {isLoading && <CardDetailSkeleton />}
+
+      {/* Error State */}
+      {isError && (
+        <div className="text-center py-12">
+          <p className="text-destructive font-medium text-lg">
+            Error loading card
+          </p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {error instanceof Error ? error.message : "Card not found"}
+          </p>
+          <Button asChild className="mt-4">
+            <Link href="/cards">Back to Cards</Link>
+          </Button>
+        </div>
+      )}
+
+      {/* Card Detail */}
+      {card && !isLoading && <CardDetail card={card} />}
+    </div>
+  );
+}

--- a/apps/web/src/app/cards/page.tsx
+++ b/apps/web/src/app/cards/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useCards } from "@/hooks/useCards";
+import { useSets } from "@/hooks/useSets";
+import {
+  CardGrid,
+  CardGridSkeleton,
+  CardSearchInput,
+  CardFilters,
+  type CardFiltersValues,
+} from "@/components/cards";
+import { Button } from "@/components/ui/button";
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export default function CardsPage() {
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [filters, setFilters] = useState<CardFiltersValues>({
+    supertype: "all",
+    types: "all",
+    set_id: "all",
+    standard_legal: "all",
+  });
+
+  const { data: setsData } = useSets();
+
+  const searchParams = {
+    q: search || undefined,
+    supertype: filters.supertype !== "all" ? filters.supertype : undefined,
+    types: filters.types !== "all" ? filters.types : undefined,
+    set_id: filters.set_id !== "all" ? filters.set_id : undefined,
+    standard_legal: filters.standard_legal === "standard" ? true : undefined,
+    expanded_legal: filters.standard_legal === "expanded" ? true : undefined,
+    page,
+    page_size: DEFAULT_PAGE_SIZE,
+  };
+
+  const { data, isLoading, isError, error } = useCards(searchParams);
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value);
+    setPage(1); // Reset to first page on search change
+  }, []);
+
+  const handleFilterChange = useCallback(
+    (key: keyof CardFiltersValues, value: string) => {
+      setFilters((prev) => ({ ...prev, [key]: value }));
+      setPage(1); // Reset to first page on filter change
+    },
+    [],
+  );
+
+  const handlePrevPage = () => setPage((p) => Math.max(1, p - 1));
+  const handleNextPage = () => {
+    if (data && page < data.pages) {
+      setPage((p) => p + 1);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Card Database</h1>
+        <p className="text-muted-foreground">
+          Search and browse Pokemon TCG cards
+        </p>
+      </div>
+
+      {/* Search and Filters */}
+      <div className="space-y-4 mb-8">
+        <CardSearchInput
+          value={search}
+          onChange={handleSearchChange}
+          placeholder="Search by card name..."
+          className="max-w-md"
+        />
+        <CardFilters
+          values={filters}
+          onChange={handleFilterChange}
+          sets={setsData}
+        />
+      </div>
+
+      {/* Results Info */}
+      {data && (
+        <p className="text-sm text-muted-foreground mb-4">
+          Showing {data.items.length} of {data.total} cards
+          {data.pages > 1 && ` (Page ${data.page} of ${data.pages})`}
+        </p>
+      )}
+
+      {/* Error State */}
+      {isError && (
+        <div className="text-center py-12">
+          <p className="text-destructive font-medium">Error loading cards</p>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Unknown error"}
+          </p>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && <CardGridSkeleton count={DEFAULT_PAGE_SIZE} />}
+
+      {/* Card Grid */}
+      {data && !isLoading && <CardGrid cards={data.items} />}
+
+      {/* Pagination */}
+      {data && data.pages > 1 && (
+        <div className="flex justify-center gap-4 mt-8">
+          <Button
+            variant="outline"
+            onClick={handlePrevPage}
+            disabled={page === 1}
+          >
+            Previous
+          </Button>
+          <span className="flex items-center text-sm text-muted-foreground">
+            Page {page} of {data.pages}
+          </span>
+          <Button
+            variant="outline"
+            onClick={handleNextPage}
+            disabled={page >= data.pages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,9 +1,26 @@
 "use client";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
 interface ProvidersProps {
   children: React.ReactNode;
 }
 
 export function Providers({ children }: ProvidersProps) {
-  return <>{children}</>;
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60, // 1 minute
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
 }

--- a/apps/web/src/components/cards/CardDetail.tsx
+++ b/apps/web/src/components/cards/CardDetail.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type { ApiCard } from "@trainerlab/shared-types";
+import { CardImage } from "./CardImage";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface CardDetailProps {
+  card: ApiCard;
+  className?: string;
+}
+
+function StatRow({ label, value }: { label: string; value: React.ReactNode }) {
+  if (!value) return null;
+  return (
+    <div className="flex justify-between py-1 border-b border-border/50 last:border-0">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}
+
+export function CardDetail({ card, className }: CardDetailProps) {
+  const isLegalStandard = card.legalities?.standard === true;
+  const isLegalExpanded = card.legalities?.expanded === true;
+
+  return (
+    <div className={cn("flex flex-col md:flex-row gap-8", className)}>
+      {/* Card Image */}
+      <div className="flex-shrink-0">
+        <CardImage
+          src={card.image_large}
+          alt={card.name}
+          size="large"
+          priority
+          className="mx-auto md:mx-0"
+        />
+      </div>
+
+      {/* Card Details */}
+      <div className="flex-1 space-y-6">
+        {/* Header */}
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-3xl font-bold">{card.name}</h1>
+            {card.hp && (
+              <Badge variant="secondary" className="text-lg">
+                {card.hp} HP
+              </Badge>
+            )}
+          </div>
+          {card.japanese_name && (
+            <p className="text-muted-foreground">{card.japanese_name}</p>
+          )}
+          <div className="flex gap-2 mt-2">
+            <Badge>{card.supertype}</Badge>
+            {card.subtypes?.map((subtype) => (
+              <Badge key={subtype} variant="outline">
+                {subtype}
+              </Badge>
+            ))}
+            {card.types?.map((type) => (
+              <Badge key={type} variant="secondary">
+                {type}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        {/* Abilities */}
+        {card.abilities && card.abilities.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Abilities</h2>
+            {card.abilities.map((ability, i) => (
+              <div key={i} className="p-3 rounded-lg bg-muted/50 mb-2">
+                <div className="font-medium text-primary">{ability.name}</div>
+                {ability.type && (
+                  <div className="text-xs text-muted-foreground">
+                    {ability.type}
+                  </div>
+                )}
+                {ability.effect && (
+                  <p className="text-sm mt-1">{ability.effect}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Attacks */}
+        {card.attacks && card.attacks.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Attacks</h2>
+            {card.attacks.map((attack, i) => (
+              <div key={i} className="p-3 rounded-lg bg-muted/50 mb-2">
+                <div className="flex justify-between items-center">
+                  <div className="font-medium">{attack.name}</div>
+                  {attack.damage && (
+                    <div className="text-lg font-bold">{attack.damage}</div>
+                  )}
+                </div>
+                {attack.cost && attack.cost.length > 0 && (
+                  <div className="text-xs text-muted-foreground">
+                    Cost: {attack.cost.join(", ")}
+                  </div>
+                )}
+                {attack.effect && (
+                  <p className="text-sm mt-1">{attack.effect}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Stats */}
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Details</h2>
+          <div className="text-sm">
+            <StatRow label="Set" value={card.set?.name || card.set_id} />
+            <StatRow label="Number" value={card.number} />
+            <StatRow label="Rarity" value={card.rarity} />
+            <StatRow label="Evolves From" value={card.evolves_from} />
+            {card.evolves_to && card.evolves_to.length > 0 && (
+              <StatRow label="Evolves To" value={card.evolves_to.join(", ")} />
+            )}
+            <StatRow
+              label="Retreat Cost"
+              value={card.retreat_cost !== null ? card.retreat_cost : undefined}
+            />
+            {card.weaknesses && card.weaknesses.length > 0 && (
+              <StatRow
+                label="Weakness"
+                value={card.weaknesses
+                  .map((w) => `${w.type} ${w.value}`)
+                  .join(", ")}
+              />
+            )}
+            {card.resistances && card.resistances.length > 0 && (
+              <StatRow
+                label="Resistance"
+                value={card.resistances
+                  .map((r) => `${r.type} ${r.value}`)
+                  .join(", ")}
+              />
+            )}
+            <StatRow label="Regulation Mark" value={card.regulation_mark} />
+          </div>
+        </div>
+
+        {/* Legality */}
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Format Legality</h2>
+          <div className="flex gap-2">
+            <Badge variant={isLegalStandard ? "default" : "secondary"}>
+              Standard: {isLegalStandard ? "Legal" : "Not Legal"}
+            </Badge>
+            <Badge variant={isLegalExpanded ? "default" : "secondary"}>
+              Expanded: {isLegalExpanded ? "Legal" : "Not Legal"}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Rules */}
+        {card.rules && card.rules.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Rules</h2>
+            <ul className="list-disc list-inside space-y-1 text-sm">
+              {card.rules.map((rule, i) => (
+                <li key={i}>{rule}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/cards/CardFilters.tsx
+++ b/apps/web/src/components/cards/CardFilters.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { ApiSet } from "@trainerlab/shared-types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+// Pokemon TCG supertypes
+const SUPERTYPES = ["Pokemon", "Trainer", "Energy"] as const;
+
+// Pokemon TCG energy types
+const ENERGY_TYPES = [
+  "Colorless",
+  "Darkness",
+  "Dragon",
+  "Fairy",
+  "Fighting",
+  "Fire",
+  "Grass",
+  "Lightning",
+  "Metal",
+  "Psychic",
+  "Water",
+] as const;
+
+export interface CardFiltersValues {
+  supertype: string;
+  types: string;
+  set_id: string;
+  standard_legal: string;
+}
+
+interface CardFiltersProps {
+  values: CardFiltersValues;
+  onChange: (key: keyof CardFiltersValues, value: string) => void;
+  sets?: ApiSet[];
+  className?: string;
+}
+
+export function CardFilters({
+  values,
+  onChange,
+  sets = [],
+  className,
+}: CardFiltersProps) {
+  return (
+    <div className={cn("flex flex-wrap gap-3", className)}>
+      {/* Supertype filter */}
+      <Select
+        value={values.supertype}
+        onValueChange={(v) => onChange("supertype", v)}
+      >
+        <SelectTrigger className="w-[140px]">
+          <SelectValue placeholder="Type" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Types</SelectItem>
+          {SUPERTYPES.map((type) => (
+            <SelectItem key={type} value={type}>
+              {type}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Energy type filter */}
+      <Select value={values.types} onValueChange={(v) => onChange("types", v)}>
+        <SelectTrigger className="w-[140px]">
+          <SelectValue placeholder="Energy" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Energy</SelectItem>
+          {ENERGY_TYPES.map((type) => (
+            <SelectItem key={type} value={type}>
+              {type}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Set filter */}
+      <Select
+        value={values.set_id}
+        onValueChange={(v) => onChange("set_id", v)}
+      >
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Set" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Sets</SelectItem>
+          {sets.map((set) => (
+            <SelectItem key={set.id} value={set.id}>
+              {set.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Legality filter */}
+      <Select
+        value={values.standard_legal}
+        onValueChange={(v) => onChange("standard_legal", v)}
+      >
+        <SelectTrigger className="w-[140px]">
+          <SelectValue placeholder="Format" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Formats</SelectItem>
+          <SelectItem value="standard">Standard Legal</SelectItem>
+          <SelectItem value="expanded">Expanded Legal</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/src/components/cards/CardGrid.tsx
+++ b/apps/web/src/components/cards/CardGrid.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import type { ApiCardSummary } from "@trainerlab/shared-types";
+import { CardImage } from "./CardImage";
+import { cn } from "@/lib/utils";
+
+interface CardGridProps {
+  cards: ApiCardSummary[];
+  className?: string;
+}
+
+interface CardGridItemProps {
+  card: ApiCardSummary;
+}
+
+function CardGridItem({ card }: CardGridItemProps) {
+  return (
+    <Link
+      href={`/cards/${card.id}`}
+      className="group flex flex-col gap-2 transition-transform hover:scale-105"
+    >
+      <CardImage
+        src={card.image_small}
+        alt={card.name}
+        size="small"
+        className="shadow-md group-hover:shadow-lg transition-shadow"
+      />
+      <div className="px-1">
+        <h3 className="font-medium text-sm truncate">{card.name}</h3>
+        <p className="text-xs text-muted-foreground">
+          {card.supertype}
+          {card.types && card.types.length > 0 && ` - ${card.types.join("/")}`}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export function CardGrid({ cards, className }: CardGridProps) {
+  if (cards.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <p className="text-lg font-medium text-muted-foreground">
+          No cards found
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Try adjusting your search or filters
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "grid gap-4",
+        "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6",
+        className,
+      )}
+    >
+      {cards.map((card) => (
+        <CardGridItem key={card.id} card={card} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/cards/CardGridSkeleton.tsx
+++ b/apps/web/src/components/cards/CardGridSkeleton.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+interface CardGridSkeletonProps {
+  count?: number;
+  className?: string;
+}
+
+function CardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Card image skeleton */}
+      <div
+        className="relative overflow-hidden rounded-lg bg-muted animate-pulse"
+        style={{ width: 160, height: 224 }}
+      >
+        <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/20 to-transparent animate-[shimmer_2s_infinite]" />
+      </div>
+      {/* Card name skeleton */}
+      <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+      {/* Card type skeleton */}
+      <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
+    </div>
+  );
+}
+
+export function CardGridSkeleton({
+  count = 12,
+  className,
+}: CardGridSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "grid gap-4",
+        "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6",
+        className,
+      )}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <CardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/cards/CardImage.tsx
+++ b/apps/web/src/components/cards/CardImage.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import { ImageOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CardImageProps {
+  src: string | null | undefined;
+  alt: string;
+  size?: "small" | "large";
+  className?: string;
+  priority?: boolean;
+}
+
+// Card aspect ratio is roughly 2.5:3.5 (poker card)
+const SIZES = {
+  small: { width: 160, height: 224 },
+  large: { width: 320, height: 448 },
+} as const;
+
+function Placeholder({ size }: { size: "small" | "large" }) {
+  const iconSize = size === "large" ? 48 : 24;
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-muted">
+      <ImageOff className="text-muted-foreground" size={iconSize} />
+    </div>
+  );
+}
+
+export function CardImage({
+  src,
+  alt,
+  size = "small",
+  className,
+  priority = false,
+}: CardImageProps) {
+  const [error, setError] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const { width, height } = SIZES[size];
+
+  const showPlaceholder = error || !src;
+
+  return (
+    <div
+      className={cn("relative overflow-hidden rounded-lg bg-muted", className)}
+      style={{ width, height }}
+    >
+      {showPlaceholder ? (
+        <Placeholder size={size} />
+      ) : (
+        <>
+          {!loaded && <Placeholder size={size} />}
+          <Image
+            src={src}
+            alt={alt}
+            width={width}
+            height={height}
+            className={cn("object-cover", !loaded && "opacity-0")}
+            onError={() => setError(true)}
+            onLoad={() => setLoaded(true)}
+            priority={priority}
+            unoptimized={src.startsWith("http")}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/cards/CardSearchInput.tsx
+++ b/apps/web/src/components/cards/CardSearchInput.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface CardSearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  debounceMs?: number;
+}
+
+export function CardSearchInput({
+  value,
+  onChange,
+  placeholder = "Search cards...",
+  className,
+  debounceMs = 300,
+}: CardSearchInputProps) {
+  const [localValue, setLocalValue] = useState(value);
+
+  // Sync external value changes
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  // Debounced onChange
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (localValue !== value) {
+        onChange(localValue);
+      }
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [localValue, value, onChange, debounceMs]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalValue(e.target.value);
+  }, []);
+
+  return (
+    <div className={cn("relative", className)}>
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        type="search"
+        value={localValue}
+        onChange={handleChange}
+        placeholder={placeholder}
+        className="pl-10"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/cards/index.ts
+++ b/apps/web/src/components/cards/index.ts
@@ -1,0 +1,6 @@
+export { CardImage } from "./CardImage";
+export { CardGrid } from "./CardGrid";
+export { CardGridSkeleton } from "./CardGridSkeleton";
+export { CardSearchInput } from "./CardSearchInput";
+export { CardFilters, type CardFiltersValues } from "./CardFilters";
+export { CardDetail } from "./CardDetail";

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useCards, useCard } from "./useCards";
+export { useSets, useSet, useSetCards } from "./useSets";

--- a/apps/web/src/hooks/useCards.ts
+++ b/apps/web/src/hooks/useCards.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { cardsApi, type CardSearchParams } from "@/lib/api";
+
+export function useCards(params: CardSearchParams = {}) {
+  return useQuery({
+    queryKey: ["cards", params],
+    queryFn: () => cardsApi.search(params),
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+}
+
+export function useCard(id: string) {
+  return useQuery({
+    queryKey: ["card", id],
+    queryFn: () => cardsApi.getById(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+}

--- a/apps/web/src/hooks/useSets.ts
+++ b/apps/web/src/hooks/useSets.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { setsApi } from "@/lib/api";
+
+export function useSets() {
+  return useQuery({
+    queryKey: ["sets"],
+    queryFn: () => setsApi.list(),
+    staleTime: 1000 * 60 * 30, // 30 minutes (sets don't change often)
+  });
+}
+
+export function useSet(id: string) {
+  return useQuery({
+    queryKey: ["set", id],
+    queryFn: () => setsApi.getById(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 30,
+  });
+}
+
+export function useSetCards(id: string, page = 1, pageSize = 20) {
+  return useQuery({
+    queryKey: ["set-cards", id, page, pageSize],
+    queryFn: () => setsApi.getCards(id, page, pageSize),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,106 @@
+/**
+ * API client for TrainerLab backend.
+ */
+
+import type {
+  ApiCard,
+  ApiCardSummary,
+  ApiSet,
+  ApiPaginatedResponse,
+} from "@trainerlab/shared-types";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public body?: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function fetchApi<T>(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<T> {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => undefined);
+    throw new ApiError(
+      `API request failed: ${response.status} ${response.statusText}`,
+      response.status,
+      body,
+    );
+  }
+
+  return response.json();
+}
+
+// Card search parameters
+export interface CardSearchParams {
+  q?: string;
+  supertype?: string;
+  types?: string;
+  set_id?: string;
+  standard_legal?: boolean;
+  expanded_legal?: boolean;
+  page?: number;
+  page_size?: number;
+}
+
+// Cards API
+export const cardsApi = {
+  search: (params: CardSearchParams = {}) => {
+    const searchParams = new URLSearchParams();
+    if (params.q) searchParams.set("q", params.q);
+    if (params.supertype) searchParams.set("supertype", params.supertype);
+    if (params.types) searchParams.set("types", params.types);
+    if (params.set_id) searchParams.set("set_id", params.set_id);
+    if (params.standard_legal !== undefined)
+      searchParams.set("standard_legal", String(params.standard_legal));
+    if (params.expanded_legal !== undefined)
+      searchParams.set("expanded_legal", String(params.expanded_legal));
+    if (params.page) searchParams.set("page", String(params.page));
+    if (params.page_size)
+      searchParams.set("page_size", String(params.page_size));
+
+    const query = searchParams.toString();
+    return fetchApi<ApiPaginatedResponse<ApiCardSummary>>(
+      `/api/v1/cards${query ? `?${query}` : ""}`,
+    );
+  },
+
+  getById: (id: string) => {
+    return fetchApi<ApiCard>(`/api/v1/cards/${encodeURIComponent(id)}`);
+  },
+};
+
+// Sets API
+export const setsApi = {
+  list: () => {
+    return fetchApi<ApiSet[]>("/api/v1/sets");
+  },
+
+  getById: (id: string) => {
+    return fetchApi<ApiSet>(`/api/v1/sets/${encodeURIComponent(id)}`);
+  },
+
+  getCards: (id: string, page = 1, pageSize = 20) => {
+    return fetchApi<ApiPaginatedResponse<ApiCardSummary>>(
+      `/api/v1/sets/${encodeURIComponent(id)}/cards?page=${page}&page_size=${pageSize}`,
+    );
+  },
+};
+
+export { ApiError };

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -49,6 +49,11 @@ const config: Config = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      keyframes: {
+        shimmer: {
+          "100%": { transform: "translateX(100%)" },
+        },
+      },
     },
   },
   plugins: [],

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -8,6 +8,13 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/shared-types/src/__tests__/types.test.ts
+++ b/packages/shared-types/src/__tests__/types.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
-import type { Card, Set, Deck, DeckCard, User } from "../index";
+import type {
+  Card,
+  Set,
+  Deck,
+  DeckCard,
+  User,
+  ApiCard,
+  ApiCardSummary,
+  ApiSet,
+  ApiPaginatedResponse,
+} from "../index";
 
 describe("Card type", () => {
   it("accepts valid card with required fields", () => {
@@ -134,5 +144,100 @@ describe("User type", () => {
     };
 
     expect(user.displayName).toBe("Ash Ketchum");
+  });
+});
+
+// API response types (snake_case, matching backend)
+describe("ApiCard type", () => {
+  it("accepts valid API card response", () => {
+    const card: ApiCard = {
+      id: "sv4-6",
+      local_id: "6",
+      name: "Charizard ex",
+      supertype: "Pokemon",
+      set_id: "sv4",
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+
+    expect(card.id).toBe("sv4-6");
+    expect(card.set_id).toBe("sv4");
+  });
+
+  it("accepts API card with all fields", () => {
+    const card: ApiCard = {
+      id: "sv4-6",
+      local_id: "6",
+      name: "Charizard ex",
+      japanese_name: "リザードンex",
+      supertype: "Pokemon",
+      subtypes: ["Stage 2", "ex"],
+      types: ["Fire"],
+      hp: 330,
+      attacks: [{ name: "Flare Blitz", cost: ["Fire", "Fire"], damage: "180" }],
+      abilities: [{ name: "Inferno Reign", effect: "Draw cards" }],
+      weaknesses: [{ type: "Water", value: "x2" }],
+      set_id: "sv4",
+      rarity: "Double Rare",
+      number: "6",
+      image_small: "https://example.com/small.png",
+      image_large: "https://example.com/large.png",
+      regulation_mark: "G",
+      legalities: { standard: true, expanded: true },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+
+    expect(card.japanese_name).toBe("リザードンex");
+    expect(card.hp).toBe(330);
+  });
+});
+
+describe("ApiCardSummary type", () => {
+  it("accepts valid API card summary", () => {
+    const summary: ApiCardSummary = {
+      id: "sv4-6",
+      name: "Charizard ex",
+      supertype: "Pokemon",
+      set_id: "sv4",
+    };
+
+    expect(summary.name).toBe("Charizard ex");
+  });
+});
+
+describe("ApiSet type", () => {
+  it("accepts valid API set response", () => {
+    const set: ApiSet = {
+      id: "sv4",
+      name: "Paradox Rift",
+      series: "Scarlet & Violet",
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+
+    expect(set.id).toBe("sv4");
+  });
+});
+
+describe("ApiPaginatedResponse type", () => {
+  it("accepts valid paginated response", () => {
+    const response: ApiPaginatedResponse<ApiCardSummary> = {
+      items: [
+        {
+          id: "sv4-6",
+          name: "Charizard ex",
+          supertype: "Pokemon",
+          set_id: "sv4",
+        },
+      ],
+      total: 100,
+      page: 1,
+      page_size: 20,
+      pages: 5,
+    };
+
+    expect(response.items).toHaveLength(1);
+    expect(response.total).toBe(100);
   });
 });

--- a/packages/shared-types/src/card.ts
+++ b/packages/shared-types/src/card.ts
@@ -1,0 +1,88 @@
+/**
+ * Card-related TypeScript types matching API schemas (snake_case).
+ * These types match the JSON responses from the FastAPI backend.
+ */
+
+export interface ApiAttack {
+  name: string;
+  cost: string[];
+  damage?: string | null;
+  effect?: string | null;
+}
+
+export interface ApiAbility {
+  name: string;
+  type?: string | null;
+  effect?: string | null;
+}
+
+export interface ApiWeaknessResistance {
+  type: string;
+  value: string;
+}
+
+export interface ApiSetSummary {
+  id: string;
+  name: string;
+  series: string;
+  release_date?: string | null;
+  logo_url?: string | null;
+  symbol_url?: string | null;
+}
+
+export interface ApiCardSummary {
+  id: string;
+  name: string;
+  supertype: string;
+  types?: string[] | null;
+  set_id: string;
+  rarity?: string | null;
+  image_small?: string | null;
+}
+
+export interface ApiCard {
+  // Identifiers
+  id: string;
+  local_id: string;
+  name: string;
+  japanese_name?: string | null;
+
+  // Card type
+  supertype: string;
+  subtypes?: string[] | null;
+  types?: string[] | null;
+
+  // Pokemon stats
+  hp?: number | null;
+  stage?: string | null;
+  evolves_from?: string | null;
+  evolves_to?: string[] | null;
+
+  // Game mechanics
+  attacks?: ApiAttack[] | null;
+  abilities?: ApiAbility[] | null;
+  weaknesses?: ApiWeaknessResistance[] | null;
+  resistances?: ApiWeaknessResistance[] | null;
+  retreat_cost?: number | null;
+  rules?: string[] | null;
+
+  // Set info
+  set_id: string;
+  rarity?: string | null;
+  number?: string | null;
+
+  // Images
+  image_small?: string | null;
+  image_large?: string | null;
+
+  // Legality
+  regulation_mark?: string | null;
+  legalities?: Record<string, boolean> | null;
+
+  // Timestamps
+  created_at: string;
+  updated_at: string;
+
+  // Nested relationships
+  set?: ApiSetSummary | null;
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,4 +1,11 @@
-// Card types
+// API response types (snake_case, matching backend schemas)
+export * from "./card";
+export * from "./set";
+export * from "./pagination";
+
+// Frontend types (camelCase, for deck builder etc.)
+// These match the original shared-types naming conventions
+
 export interface Card {
   id: string;
   nameEn: string;
@@ -18,7 +25,6 @@ export interface Card {
   regulationMark?: string;
 }
 
-// Set types
 export interface Set {
   id: string;
   name: string;
@@ -30,7 +36,6 @@ export interface Set {
   symbolUrl?: string;
 }
 
-// Deck types
 export interface DeckCard {
   cardId: string;
   quantity: number;
@@ -53,7 +58,6 @@ export interface Deck {
   updatedAt: string;
 }
 
-// User types
 export interface User {
   id: string;
   email: string;

--- a/packages/shared-types/src/pagination.ts
+++ b/packages/shared-types/src/pagination.ts
@@ -1,0 +1,12 @@
+/**
+ * Pagination types for API responses (snake_case).
+ * These types match the JSON responses from the FastAPI backend.
+ */
+
+export interface ApiPaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+  pages: number;
+}

--- a/packages/shared-types/src/set.ts
+++ b/packages/shared-types/src/set.ts
@@ -1,0 +1,27 @@
+/**
+ * Set-related TypeScript types matching API schemas (snake_case).
+ * These types match the JSON responses from the FastAPI backend.
+ */
+
+export interface ApiSet {
+  // Identifiers
+  id: string;
+  name: string;
+  series: string;
+
+  // Release info
+  release_date?: string | null;
+  release_date_jp?: string | null;
+  card_count?: number | null;
+
+  // Images
+  logo_url?: string | null;
+  symbol_url?: string | null;
+
+  // Legalities
+  legalities?: Record<string, string> | null;
+
+  // Timestamps
+  created_at: string;
+  updated_at: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,18 @@ importers:
 
   apps/web:
     dependencies:
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.4(@types/react@18.3.27)(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.90.20
+        version: 5.90.20(react@18.3.1)
+      '@trainerlab/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -273,6 +282,21 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
+
+  '@floating-ui/react-dom@2.1.7':
+    resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -390,8 +414,163 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -407,6 +586,94 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rollup/rollup-android-arm-eabi@4.57.0':
     resolution: {integrity: sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==}
@@ -544,6 +811,14 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/react-query@5.90.20':
+    resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -805,6 +1080,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1026,6 +1305,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1304,6 +1586,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -1900,6 +2186,36 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2224,6 +2540,26 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2465,6 +2801,23 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2559,8 +2912,155 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@radix-ui/number@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.27)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
@@ -2571,6 +3071,71 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.57.0':
     optional: true
@@ -2657,6 +3222,13 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.20(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 18.3.1
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -2926,6 +3498,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -3172,6 +3748,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -3622,6 +4200,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -4212,6 +4792,33 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.27)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  react-remove-scroll@2.7.2(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.27)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.27)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.27)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.27)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  react-style-singleton@2.2.3(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4661,6 +5268,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
+  use-sidecar@1.1.3(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Add card search UI with TanStack Query, components, and API client:
- API types (ApiCard, ApiSet, ApiPaginatedResponse) in shared-types
- API client with cardsApi and setsApi
- Card components (CardGrid, CardDetail, CardFilters, CardSearchInput)
- TanStack Query hooks (useCards, useSets)
- Card search page (/cards) and detail page (/cards/[id])
- QueryClientProvider in app providers