### PR TITLE
feat: frontend TypeScript types and API client (#60-65)

### DIFF
--- a/apps/web/src/app/cards/page.tsx
+++ b/apps/web/src/app/cards/page.tsx
@@ -31,10 +31,10 @@ export default function CardsPage() {
     supertype: filters.supertype !== "all" ? filters.supertype : undefined,
     types: filters.types !== "all" ? filters.types : undefined,
     set_id: filters.set_id !== "all" ? filters.set_id : undefined,
-    standard_legal: filters.standard_legal === "standard" ? true : undefined,
-    expanded_legal: filters.standard_legal === "expanded" ? true : undefined,
+    standard: filters.standard_legal === "standard" ? true : undefined,
+    expanded: filters.standard_legal === "expanded" ? true : undefined,
     page,
-    page_size: DEFAULT_PAGE_SIZE,
+    limit: DEFAULT_PAGE_SIZE,
   };
 
   const { data, isLoading, isError, error } = useCards(searchParams);
@@ -54,7 +54,7 @@ export default function CardsPage() {
 
   const handlePrevPage = () => setPage((p) => Math.max(1, p - 1));
   const handleNextPage = () => {
-    if (data && page < data.pages) {
+    if (data && page < data.total_pages) {
       setPage((p) => p + 1);
     }
   };
@@ -87,7 +87,8 @@ export default function CardsPage() {
       {data && (
         <p className="text-sm text-muted-foreground mb-4">
           Showing {data.items.length} of {data.total} cards
-          {data.pages > 1 && ` (Page ${data.page} of ${data.pages})`}
+          {data.total_pages > 1 &&
+            ` (Page ${data.page} of ${data.total_pages})`}
         </p>
       )}
 
@@ -108,7 +109,7 @@ export default function CardsPage() {
       {data && !isLoading && <CardGrid cards={data.items} />}
 
       {/* Pagination */}
-      {data && data.pages > 1 && (
+      {data && data.total_pages > 1 && (
         <div className="flex justify-center gap-4 mt-8">
           <Button
             variant="outline"
@@ -118,12 +119,12 @@ export default function CardsPage() {
             Previous
           </Button>
           <span className="flex items-center text-sm text-muted-foreground">
-            Page {page} of {data.pages}
+            Page {page} of {data.total_pages}
           </span>
           <Button
             variant="outline"
             onClick={handleNextPage}
-            disabled={page >= data.pages}
+            disabled={page >= data.total_pages}
           >
             Next
           </Button>

--- a/apps/web/src/hooks/useSets.ts
+++ b/apps/web/src/hooks/useSets.ts
@@ -20,10 +20,10 @@ export function useSet(id: string) {
   });
 }
 
-export function useSetCards(id: string, page = 1, pageSize = 20) {
+export function useSetCards(id: string, page = 1, limit = 20) {
   return useQuery({
-    queryKey: ["set-cards", id, page, pageSize],
-    queryFn: () => setsApi.getCards(id, page, pageSize),
+    queryKey: ["set-cards", id, page, limit],
+    queryFn: () => setsApi.getCards(id, page, limit),
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -53,10 +53,10 @@ export interface CardSearchParams {
   supertype?: string;
   types?: string;
   set_id?: string;
-  standard_legal?: boolean;
-  expanded_legal?: boolean;
+  standard?: boolean;
+  expanded?: boolean;
   page?: number;
-  page_size?: number;
+  limit?: number;
 }
 
 // Cards API
@@ -67,13 +67,12 @@ export const cardsApi = {
     if (params.supertype) searchParams.set("supertype", params.supertype);
     if (params.types) searchParams.set("types", params.types);
     if (params.set_id) searchParams.set("set_id", params.set_id);
-    if (params.standard_legal !== undefined)
-      searchParams.set("standard_legal", String(params.standard_legal));
-    if (params.expanded_legal !== undefined)
-      searchParams.set("expanded_legal", String(params.expanded_legal));
+    if (params.standard !== undefined)
+      searchParams.set("standard", String(params.standard));
+    if (params.expanded !== undefined)
+      searchParams.set("expanded", String(params.expanded));
     if (params.page) searchParams.set("page", String(params.page));
-    if (params.page_size)
-      searchParams.set("page_size", String(params.page_size));
+    if (params.limit) searchParams.set("limit", String(params.limit));
 
     const query = searchParams.toString();
     return fetchApi<ApiPaginatedResponse<ApiCardSummary>>(
@@ -96,9 +95,9 @@ export const setsApi = {
     return fetchApi<ApiSet>(`/api/v1/sets/${encodeURIComponent(id)}`);
   },
 
-  getCards: (id: string, page = 1, pageSize = 20) => {
+  getCards: (id: string, page = 1, limit = 20) => {
     return fetchApi<ApiPaginatedResponse<ApiCardSummary>>(
-      `/api/v1/sets/${encodeURIComponent(id)}/cards?page=${page}&page_size=${pageSize}`,
+      `/api/v1/sets/${encodeURIComponent(id)}/cards?page=${page}&limit=${limit}`,
     );
   },
 };

--- a/packages/shared-types/src/__tests__/types.test.ts
+++ b/packages/shared-types/src/__tests__/types.test.ts
@@ -233,11 +233,31 @@ describe("ApiPaginatedResponse type", () => {
       ],
       total: 100,
       page: 1,
-      page_size: 20,
-      pages: 5,
+      limit: 20,
+      has_next: true,
+      has_prev: false,
+      total_pages: 5,
     };
 
     expect(response.items).toHaveLength(1);
     expect(response.total).toBe(100);
+    expect(response.has_next).toBe(true);
+    expect(response.has_prev).toBe(false);
+    expect(response.total_pages).toBe(5);
+  });
+
+  it("accepts paginated response with next_cursor", () => {
+    const response: ApiPaginatedResponse<ApiCardSummary> = {
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+      has_next: false,
+      has_prev: false,
+      total_pages: 0,
+      next_cursor: "cursor123",
+    };
+
+    expect(response.next_cursor).toBe("cursor123");
   });
 });

--- a/packages/shared-types/src/pagination.ts
+++ b/packages/shared-types/src/pagination.ts
@@ -7,6 +7,9 @@ export interface ApiPaginatedResponse<T> {
   items: T[];
   total: number;
   page: number;
-  page_size: number;
-  pages: number;
+  limit: number;
+  has_next: boolean;
+  has_prev: boolean;
+  total_pages: number;
+  next_cursor?: string | null;
 }


### PR DESCRIPTION
## Summary

Aligns frontend TypeScript types and API client with actual backend schemas. These issues were partially implemented before but had type mismatches with the API.

## Issues Addressed
- #60: Create Card TypeScript type
- #61: Create Set TypeScript type  
- #62: Create PaginatedResponse TypeScript type
- #63: Create lib/api.ts base client with fetch
- #64: Add searchCards function to API client
- #65: Add getCard function to API client

## Changes

**packages/shared-types/src/pagination.ts**
- Updated `ApiPaginatedResponse` to match actual API response:
  - `limit` instead of `page_size`
  - Added `has_next`, `has_prev`, `total_pages`, `next_cursor`

**apps/web/src/lib/api.ts**
- Fixed `CardSearchParams` to use correct param names (`standard`/`expanded` instead of `standard_legal`/`expanded_legal`, `limit` instead of `page_size`)
- Updated query param building to match API expectations

**apps/web/src/app/cards/page.tsx**
- Updated to use new pagination fields (`total_pages` instead of `pages`)

**apps/web/src/hooks/useSets.ts**
- Renamed `pageSize` parameter to `limit`

## Testing
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `@trainerlab/shared-types` tests pass (17 tests)

Closes #60, closes #61, closes #62, closes #63, closes #64, closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)