### PR TITLE
feat: complete card components (#66-70)

### DIFF
--- a/apps/web/src/components/cards/CardSearchInput.tsx
+++ b/apps/web/src/components/cards/CardSearchInput.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface CardSearchInputProps {
@@ -42,6 +43,11 @@ export function CardSearchInput({
     setLocalValue(e.target.value);
   }, []);
 
+  const handleClear = useCallback(() => {
+    setLocalValue("");
+    onChange("");
+  }, [onChange]);
+
   return (
     <div className={cn("relative", className)}>
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -50,8 +56,20 @@ export function CardSearchInput({
         value={localValue}
         onChange={handleChange}
         placeholder={placeholder}
-        className="pl-10"
+        className="pl-10 pr-10"
       />
+      {localValue && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleClear}
+          className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 p-0 hover:bg-transparent"
+        >
+          <X className="h-4 w-4 text-muted-foreground" />
+          <span className="sr-only">Clear search</span>
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes out Phase 2 frontend card component issues. Most functionality was already implemented - this PR adds the missing clear button to CardSearchInput.

## Issues Addressed
- #66: Add getSets function to API client - Already implemented as `setsApi.list()`
- #67: Create CardImage component - Already implemented with loading/error states and size variants
- #68: Create CardGridSkeleton component - Already implemented with shimmer animation
- #69: Create CardGrid component - Already implemented with responsive columns and empty state
- #70: Create CardSearchInput component - **Added missing clear button**

## Changes

**apps/web/src/components/cards/CardSearchInput.tsx**
- Added clear (X) button that appears when input has text
- Button immediately clears both local state and triggers onChange
- Added accessible sr-only label for screen readers

## Testing
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

Closes #66, closes #67, closes #68, closes #69, closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)