### PR TITLE
feat: complete card pages and components (#71-77)

### DIFF
--- a/apps/web/src/app/cards/[id]/CardDetailClient.tsx
+++ b/apps/web/src/app/cards/[id]/CardDetailClient.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useCard } from "@/hooks/useCards";
+import { CardDetail } from "@/components/cards";
+import { Button } from "@/components/ui/button";
+
+interface CardDetailClientProps {
+  id: string;
+}
+
+function CardDetailSkeleton() {
+  return (
+    <div className="flex flex-col md:flex-row gap-8 animate-pulse">
+      <div
+        className="bg-muted rounded-lg flex-shrink-0 mx-auto md:mx-0"
+        style={{ width: 320, height: 448 }}
+      />
+      <div className="flex-1 space-y-4">
+        <div className="h-8 bg-muted rounded w-1/2" />
+        <div className="h-4 bg-muted rounded w-1/3" />
+        <div className="flex gap-2">
+          <div className="h-6 bg-muted rounded w-20" />
+          <div className="h-6 bg-muted rounded w-20" />
+        </div>
+        <div className="h-24 bg-muted rounded" />
+        <div className="h-24 bg-muted rounded" />
+      </div>
+    </div>
+  );
+}
+
+export function CardDetailClient({ id }: CardDetailClientProps) {
+  const { data: card, isLoading, isError, error } = useCard(id);
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      {/* Back Button */}
+      <Button variant="ghost" asChild className="mb-6">
+        <Link href="/cards">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Cards
+        </Link>
+      </Button>
+
+      {/* Loading State */}
+      {isLoading && <CardDetailSkeleton />}
+
+      {/* Error State */}
+      {isError && (
+        <div className="text-center py-12">
+          <p className="text-destructive font-medium text-lg">
+            Error loading card
+          </p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {error instanceof Error ? error.message : "Card not found"}
+          </p>
+          <Button asChild className="mt-4">
+            <Link href="/cards">Back to Cards</Link>
+          </Button>
+        </div>
+      )}
+
+      {/* Card Detail */}
+      {card && !isLoading && <CardDetail card={card} />}
+    </div>
+  );
+}

--- a/apps/web/src/app/cards/[id]/page.tsx
+++ b/apps/web/src/app/cards/[id]/page.tsx
@@ -1,71 +1,52 @@
-"use client";
+import type { Metadata } from "next";
+import { CardDetailClient } from "./CardDetailClient";
 
-import { use } from "react";
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
-import { useCard } from "@/hooks/useCards";
-import { CardDetail } from "@/components/cards";
-import { Button } from "@/components/ui/button";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 interface CardDetailPageProps {
   params: Promise<{ id: string }>;
 }
 
-function CardDetailSkeleton() {
-  return (
-    <div className="flex flex-col md:flex-row gap-8 animate-pulse">
-      <div
-        className="bg-muted rounded-lg flex-shrink-0 mx-auto md:mx-0"
-        style={{ width: 320, height: 448 }}
-      />
-      <div className="flex-1 space-y-4">
-        <div className="h-8 bg-muted rounded w-1/2" />
-        <div className="h-4 bg-muted rounded w-1/3" />
-        <div className="flex gap-2">
-          <div className="h-6 bg-muted rounded w-20" />
-          <div className="h-6 bg-muted rounded w-20" />
-        </div>
-        <div className="h-24 bg-muted rounded" />
-        <div className="h-24 bg-muted rounded" />
-      </div>
-    </div>
-  );
+export async function generateMetadata({
+  params,
+}: CardDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/cards/${encodeURIComponent(id)}`,
+      { next: { revalidate: 3600 } }, // Cache for 1 hour
+    );
+
+    if (!response.ok) {
+      return {
+        title: "Card Not Found | TrainerLab",
+        description: "The requested Pokemon TCG card could not be found.",
+      };
+    }
+
+    const card = await response.json();
+    const title = `${card.name} | TrainerLab`;
+    const description = `View ${card.name} from ${card.set?.name || card.set_id}. ${card.supertype}${card.types?.length ? ` - ${card.types.join("/")}` : ""}${card.hp ? ` - ${card.hp} HP` : ""}.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        images: card.image_large ? [{ url: card.image_large }] : undefined,
+      },
+    };
+  } catch {
+    return {
+      title: "Card | TrainerLab",
+      description: "View Pokemon TCG card details on TrainerLab.",
+    };
+  }
 }
 
-export default function CardDetailPage({ params }: CardDetailPageProps) {
-  const { id } = use(params);
-  const { data: card, isLoading, isError, error } = useCard(id);
-
-  return (
-    <div className="container mx-auto py-8 px-4">
-      {/* Back Button */}
-      <Button variant="ghost" asChild className="mb-6">
-        <Link href="/cards">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Cards
-        </Link>
-      </Button>
-
-      {/* Loading State */}
-      {isLoading && <CardDetailSkeleton />}
-
-      {/* Error State */}
-      {isError && (
-        <div className="text-center py-12">
-          <p className="text-destructive font-medium text-lg">
-            Error loading card
-          </p>
-          <p className="text-sm text-muted-foreground mt-2">
-            {error instanceof Error ? error.message : "Card not found"}
-          </p>
-          <Button asChild className="mt-4">
-            <Link href="/cards">Back to Cards</Link>
-          </Button>
-        </div>
-      )}
-
-      {/* Card Detail */}
-      {card && !isLoading && <CardDetail card={card} />}
-    </div>
-  );
+export default async function CardDetailPage({ params }: CardDetailPageProps) {
+  const { id } = await params;
+  return <CardDetailClient id={id} />;
 }

--- a/apps/web/src/app/cards/layout.tsx
+++ b/apps/web/src/app/cards/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Card Database | TrainerLab",
+  description:
+    "Browse and search the complete Pokemon TCG card database. Filter by type, set, format legality, and more.",
+  openGraph: {
+    title: "Card Database | TrainerLab",
+    description:
+      "Browse and search the complete Pokemon TCG card database. Filter by type, set, format legality, and more.",
+  },
+};
+
+export default function CardsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/src/app/cards/page.tsx
+++ b/apps/web/src/app/cards/page.tsx
@@ -8,6 +8,7 @@ import {
   CardGridSkeleton,
   CardSearchInput,
   CardFilters,
+  DEFAULT_FILTERS,
   type CardFiltersValues,
 } from "@/components/cards";
 import { Button } from "@/components/ui/button";
@@ -17,12 +18,7 @@ const DEFAULT_PAGE_SIZE = 20;
 export default function CardsPage() {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
-  const [filters, setFilters] = useState<CardFiltersValues>({
-    supertype: "all",
-    types: "all",
-    set_id: "all",
-    standard_legal: "all",
-  });
+  const [filters, setFilters] = useState<CardFiltersValues>(DEFAULT_FILTERS);
 
   const { data: setsData } = useSets();
 
@@ -52,6 +48,11 @@ export default function CardsPage() {
     [],
   );
 
+  const handleClearFilters = useCallback(() => {
+    setFilters(DEFAULT_FILTERS);
+    setPage(1);
+  }, []);
+
   const handlePrevPage = () => setPage((p) => Math.max(1, p - 1));
   const handleNextPage = () => {
     if (data && page < data.total_pages) {
@@ -79,6 +80,7 @@ export default function CardsPage() {
         <CardFilters
           values={filters}
           onChange={handleFilterChange}
+          onClear={handleClearFilters}
           sets={setsData}
         />
       </div>

--- a/apps/web/src/components/cards/CardFilters.tsx
+++ b/apps/web/src/components/cards/CardFilters.tsx
@@ -8,6 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Pokemon TCG supertypes
@@ -28,6 +30,13 @@ const ENERGY_TYPES = [
   "Water",
 ] as const;
 
+export const DEFAULT_FILTERS: CardFiltersValues = {
+  supertype: "all",
+  types: "all",
+  set_id: "all",
+  standard_legal: "all",
+};
+
 export interface CardFiltersValues {
   supertype: string;
   types: string;
@@ -38,6 +47,7 @@ export interface CardFiltersValues {
 interface CardFiltersProps {
   values: CardFiltersValues;
   onChange: (key: keyof CardFiltersValues, value: string) => void;
+  onClear?: () => void;
   sets?: ApiSet[];
   className?: string;
 }
@@ -45,11 +55,18 @@ interface CardFiltersProps {
 export function CardFilters({
   values,
   onChange,
+  onClear,
   sets = [],
   className,
 }: CardFiltersProps) {
+  const hasActiveFilters =
+    values.supertype !== "all" ||
+    values.types !== "all" ||
+    values.set_id !== "all" ||
+    values.standard_legal !== "all";
+
   return (
-    <div className={cn("flex flex-wrap gap-3", className)}>
+    <div className={cn("flex flex-wrap gap-3 items-center", className)}>
       {/* Supertype filter */}
       <Select
         value={values.supertype}
@@ -115,6 +132,19 @@ export function CardFilters({
           <SelectItem value="expanded">Expanded Legal</SelectItem>
         </SelectContent>
       </Select>
+
+      {/* Clear filters button */}
+      {hasActiveFilters && onClear && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          className="h-10 px-3 text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-4 w-4 mr-1" />
+          Clear filters
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/cards/index.ts
+++ b/apps/web/src/components/cards/index.ts
@@ -2,5 +2,9 @@ export { CardImage } from "./CardImage";
 export { CardGrid } from "./CardGrid";
 export { CardGridSkeleton } from "./CardGridSkeleton";
 export { CardSearchInput } from "./CardSearchInput";
-export { CardFilters, type CardFiltersValues } from "./CardFilters";
+export {
+  CardFilters,
+  DEFAULT_FILTERS,
+  type CardFiltersValues,
+} from "./CardFilters";
 export { CardDetail } from "./CardDetail";


### PR DESCRIPTION
## Summary

Completes Phase 2 frontend card components and pages. Most functionality was already implemented - this PR adds the missing pieces.

## Issues Addressed
- #71: Create CardFilters component - **Added clear filters button**
- #72: Create CardDetail component - Already implemented
- #73: Create useCards hook - Already implemented  
- #74: Create useSets hook - Already implemented
- #75: Build /cards page layout - **Added layout.tsx with SEO metadata**
- #76: Wire CardSearch + CardGrid on /cards - Already implemented
- #77: Build /cards/[id] page - **Added dynamic SEO metadata with generateMetadata**

## Changes

**apps/web/src/components/cards/CardFilters.tsx**
- Added clear filters button that appears when any filter is active
- Exported `DEFAULT_FILTERS` constant for consistent state management

**apps/web/src/app/cards/layout.tsx** (new)
- Added SEO metadata for card database page

**apps/web/src/app/cards/[id]/page.tsx**
- Refactored to server component with `generateMetadata` for dynamic SEO
- Card name, set, type, and image now appear in metadata

**apps/web/src/app/cards/[id]/CardDetailClient.tsx** (new)
- Extracted client-side logic to separate component

## Testing
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

Closes #71, closes #72, closes #73, closes #74, closes #75, closes #76, closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)