### PR TITLE
feat: complete clearDeck and loadDeck implementations

### DIFF
--- a/apps/web/src/stores/__tests__/deckStore.test.ts
+++ b/apps/web/src/stores/__tests__/deckStore.test.ts
@@ -285,6 +285,20 @@ describe("deckStore", () => {
       expect(state.cards).toHaveLength(0);
       expect(state.isModified).toBe(true);
     });
+
+    it("should clear name and description", () => {
+      useDeckStore.getState().setName("My Deck");
+      useDeckStore.getState().setDescription("A test deck");
+      useDeckStore.getState().addCard(createMockCard());
+
+      useDeckStore.getState().clearDeck();
+
+      const state = useDeckStore.getState();
+      expect(state.name).toBe("");
+      expect(state.description).toBe("");
+      expect(state.cards).toHaveLength(0);
+      expect(state.isModified).toBe(true);
+    });
   });
 
   describe("loadDeck", () => {

--- a/apps/web/src/stores/deckStore.ts
+++ b/apps/web/src/stores/deckStore.ts
@@ -194,7 +194,7 @@ export const useDeckStore = create<DeckState & DeckActions & DeckGetters>()(
       },
 
       clearDeck: () => {
-        set({ cards: [], isModified: true });
+        set({ cards: [], name: "", description: "", isModified: true });
       },
 
       loadDeck: (deck: Omit<DeckState, "isModified">) => {


### PR DESCRIPTION
## Summary
Implements the remaining deck store actions from Phase 3.

## Issues Addressed
- #83: Implement clearDeck action
- #84: Implement loadDeck action

## Changes
- **clearDeck**: Now properly resets name and description to empty strings (previously only cleared cards)
- **loadDeck**: Already implemented correctly, just needed verification
- Added test case for clearDeck clearing metadata

## Testing
- [x] Unit tests passing (39 tests)
- [x] TypeScript type check passing
- [x] Pre-commit hooks passing

Closes #83, closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)