### PR TITLE
feat: implement Phase 3A evolution tracking system

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -13,8 +13,13 @@ from src.db.base import Base
 
 # Import all models to ensure they're registered with Base.metadata
 from src.models import (  # noqa: F401
+    Adaptation,
+    ArchetypeEvolutionSnapshot,
+    ArchetypePrediction,
     Card,
     Deck,
+    EvolutionArticle,
+    EvolutionArticleSnapshot,
     MetaSnapshot,
     Set,
     Tournament,

--- a/apps/api/alembic/versions/20260204_0001_015_add_evolution_tables.py
+++ b/apps/api/alembic/versions/20260204_0001_015_add_evolution_tables.py
@@ -1,0 +1,219 @@
+"""Add evolution tracking tables.
+
+Creates archetype_evolution_snapshots, adaptations, archetype_predictions,
+evolution_articles, and evolution_article_snapshots tables for Phase 3A.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-02-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers
+revision: str = "015"
+down_revision: str | None = "014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create evolution tracking tables."""
+    # Archetype evolution snapshots
+    op.create_table(
+        "archetype_evolution_snapshots",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("archetype", sa.String(255), nullable=False, index=True),
+        sa.Column(
+            "tournament_id",
+            sa.Uuid(),
+            sa.ForeignKey("tournaments.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("meta_share", sa.Float(), nullable=True),
+        sa.Column("top_cut_conversion", sa.Float(), nullable=True),
+        sa.Column("best_placement", sa.Integer(), nullable=True),
+        sa.Column(
+            "deck_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("consensus_list", postgresql.JSONB(), nullable=True),
+        sa.Column("card_usage", postgresql.JSONB(), nullable=True),
+        sa.Column("meta_context", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "archetype", "tournament_id", name="uq_snapshot_archetype_tournament"
+        ),
+    )
+
+    # Adaptations
+    op.create_table(
+        "adaptations",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "snapshot_id",
+            sa.Uuid(),
+            sa.ForeignKey("archetype_evolution_snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("type", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("cards_added", postgresql.JSONB(), nullable=True),
+        sa.Column("cards_removed", postgresql.JSONB(), nullable=True),
+        sa.Column("target_archetype", sa.String(255), nullable=True),
+        sa.Column("prevalence", sa.Float(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("source", sa.String(50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # Archetype predictions
+    op.create_table(
+        "archetype_predictions",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("archetype_id", sa.String(255), nullable=False, index=True),
+        sa.Column(
+            "target_tournament_id",
+            sa.Uuid(),
+            sa.ForeignKey("tournaments.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("predicted_meta_share", postgresql.JSONB(), nullable=True),
+        sa.Column("predicted_day2_rate", postgresql.JSONB(), nullable=True),
+        sa.Column("predicted_tier", sa.String(10), nullable=True),
+        sa.Column("likely_adaptations", postgresql.JSONB(), nullable=True),
+        sa.Column("jp_signals", postgresql.JSONB(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("methodology", sa.Text(), nullable=True),
+        sa.Column("actual_meta_share", sa.Float(), nullable=True),
+        sa.Column("accuracy_score", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "archetype_id",
+            "target_tournament_id",
+            name="uq_prediction_archetype_tournament",
+        ),
+    )
+
+    # Evolution articles
+    op.create_table(
+        "evolution_articles",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("archetype_id", sa.String(255), nullable=False, index=True),
+        sa.Column("slug", sa.String(255), nullable=False, unique=True, index=True),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("excerpt", sa.String(1000), nullable=True),
+        sa.Column("introduction", sa.Text(), nullable=True),
+        sa.Column("conclusion", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'draft'"),
+            index=True,
+        ),
+        sa.Column(
+            "is_premium",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+            index=True,
+        ),
+        sa.Column(
+            "published_at", sa.DateTime(timezone=True), nullable=True, index=True
+        ),
+        sa.Column(
+            "lab_note_id",
+            sa.Uuid(),
+            sa.ForeignKey("lab_notes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("commerce_links", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "view_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "share_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # Evolution article snapshots (join table)
+    op.create_table(
+        "evolution_article_snapshots",
+        sa.Column(
+            "article_id",
+            sa.Uuid(),
+            sa.ForeignKey("evolution_articles.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "snapshot_id",
+            sa.Uuid(),
+            sa.ForeignKey("archetype_evolution_snapshots.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "position", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop evolution tracking tables."""
+    op.drop_table("evolution_article_snapshots")
+    op.drop_table("evolution_articles")
+    op.drop_table("archetype_predictions")
+    op.drop_table("adaptations")
+    op.drop_table("archetype_evolution_snapshots")

--- a/apps/api/src/data/card_reprints.py
+++ b/apps/api/src/data/card_reprints.py
@@ -1,0 +1,55 @@
+"""Card reprint mappings for treating the same card across sets as identical.
+
+Maps card_id to a canonical card name so that reprints/alt arts are treated
+as the same card when computing consensus decklists and diffs.
+"""
+
+# Maps card_id → canonical card name for cards with known reprints.
+# Only needs to cover cards that appear across multiple sets in competitive play.
+# Cards not in this mapping fall back to their decklist-provided name.
+CARD_REPRINTS: dict[str, str] = {
+    # Boss's Orders (various prints)
+    "sv2-172": "Boss's Orders",
+    "sv3-172": "Boss's Orders",
+    "sv4-172": "Boss's Orders",
+    "swsh9-132": "Boss's Orders",
+    "swsh11-154": "Boss's Orders",
+    # Professor's Research (various prints)
+    "sv1-190": "Professor's Research",
+    "sv2-189": "Professor's Research",
+    "sv4-168": "Professor's Research",
+    "swsh12pt5-78": "Professor's Research",
+    # Rare Candy
+    "sv1-191": "Rare Candy",
+    "sv4-191": "Rare Candy",
+    "swsh12pt5-69": "Rare Candy",
+    # Ultra Ball
+    "sv1-196": "Ultra Ball",
+    "sv4-196": "Ultra Ball",
+    "swsh9-150": "Ultra Ball",
+    # Nest Ball
+    "sv1-181": "Nest Ball",
+    "sv5-181": "Nest Ball",
+    # Switch
+    "sv1-194": "Switch",
+    "sv3-194": "Switch",
+    # Super Rod
+    "sv2-188": "Super Rod",
+    "sv5-188": "Super Rod",
+    # Iono
+    "sv1-185": "Iono",
+    "sv4pt5-80": "Iono",
+    "sv6-178": "Iono",
+    # Arven
+    "sv1-166": "Arven",
+    "sv3-166": "Arven",
+    # Energy (basic energy reprints across sets)
+    "sv1-svE-1": "Basic Fire Energy",
+    "sv1-svE-2": "Basic Water Energy",
+    "sv1-svE-3": "Basic Grass Energy",
+    "sv1-svE-4": "Basic Lightning Energy",
+    "sv1-svE-5": "Basic Psychic Energy",
+    "sv1-svE-6": "Basic Fighting Energy",
+    "sv1-svE-7": "Basic Darkness Energy",
+    "sv1-svE-8": "Basic Metal Energy",
+}

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -1,7 +1,12 @@
 """SQLAlchemy models."""
 
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
 from src.models.card import Card
 from src.models.deck import Deck
+from src.models.evolution_article import EvolutionArticle
+from src.models.evolution_article_snapshot import EvolutionArticleSnapshot
 from src.models.format_config import FormatConfig
 from src.models.jp_card_innovation import JPCardInnovation
 from src.models.jp_new_archetype import JPNewArchetype
@@ -18,8 +23,13 @@ from src.models.user import User
 from src.models.waitlist import WaitlistEntry
 
 __all__ = [
+    "Adaptation",
+    "ArchetypeEvolutionSnapshot",
+    "ArchetypePrediction",
     "Card",
     "Deck",
+    "EvolutionArticle",
+    "EvolutionArticleSnapshot",
     "FormatConfig",
     "JPCardInnovation",
     "JPNewArchetype",

--- a/apps/api/src/models/adaptation.py
+++ b/apps/api/src/models/adaptation.py
@@ -1,0 +1,59 @@
+"""Adaptation model for tracking changes between archetype snapshots."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Float, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+
+
+class Adaptation(Base, TimestampMixin):
+    """A specific adaptation detected between two archetype snapshots.
+
+    Records cards added/removed, the type of adaptation, and what
+    archetype it targets (if a tech choice).
+    """
+
+    __tablename__ = "adaptations"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Parent snapshot
+    snapshot_id: Mapped[UUID] = mapped_column(
+        ForeignKey("archetype_evolution_snapshots.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Adaptation details
+    type: Mapped[str] = mapped_column(
+        String(50), nullable=False
+    )  # tech, consistency, engine, removal
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Card changes
+    # Format: [{"card_id": "sv4-6", "name": "Charizard ex", "quantity": 2}]
+    cards_added: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    cards_removed: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+
+    # What this adaptation targets (e.g., "Dragapult ex" if teching against it)
+    target_archetype: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # How widespread and confident the detection is
+    prevalence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Source of classification (diff, claude, manual)
+    source: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # Relationships
+    snapshot: Mapped["ArchetypeEvolutionSnapshot"] = relationship(
+        "ArchetypeEvolutionSnapshot", back_populates="adaptations"
+    )

--- a/apps/api/src/models/archetype_evolution_snapshot.py
+++ b/apps/api/src/models/archetype_evolution_snapshot.py
@@ -1,0 +1,67 @@
+"""ArchetypeEvolutionSnapshot model for tracking archetype performance over time."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Float, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.adaptation import Adaptation
+    from src.models.evolution_article_snapshot import EvolutionArticleSnapshot
+    from src.models.tournament import Tournament
+
+
+class ArchetypeEvolutionSnapshot(Base, TimestampMixin):
+    """Snapshot of an archetype's performance at a specific tournament.
+
+    Captures meta share, top cut conversion, consensus decklist, and
+    card usage data for tracking how an archetype evolves over time.
+    """
+
+    __tablename__ = "archetype_evolution_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "archetype", "tournament_id", name="uq_snapshot_archetype_tournament"
+        ),
+    )
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Archetype identifier (normalized name)
+    archetype: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # Tournament reference
+    tournament_id: Mapped[UUID] = mapped_column(
+        ForeignKey("tournaments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Performance metrics
+    meta_share: Mapped[float | None] = mapped_column(Float, nullable=True)
+    top_cut_conversion: Mapped[float | None] = mapped_column(Float, nullable=True)
+    best_placement: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    deck_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Consensus decklist and card usage (JSONB)
+    # [{"card_id": "...", "name": "...", "quantity": N, "inclusion_rate": 0.95}]
+    consensus_list: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    # {"card_name": {"name": "...", "avg_count": 2.8, "inclusion_rate": 0.95}}
+    card_usage: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Optional context notes
+    meta_context: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Relationships
+    tournament: Mapped["Tournament"] = relationship("Tournament")
+    adaptations: Mapped[list["Adaptation"]] = relationship(
+        "Adaptation", back_populates="snapshot", cascade="all, delete-orphan"
+    )
+    article_snapshots: Mapped[list["EvolutionArticleSnapshot"]] = relationship(
+        "EvolutionArticleSnapshot",
+        back_populates="snapshot",
+        cascade="all, delete-orphan",
+    )

--- a/apps/api/src/models/archetype_prediction.py
+++ b/apps/api/src/models/archetype_prediction.py
@@ -1,0 +1,63 @@
+"""ArchetypePrediction model for forecasting archetype performance."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Float, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.tournament import Tournament
+
+
+class ArchetypePrediction(Base, TimestampMixin):
+    """Prediction for an archetype's performance at an upcoming tournament.
+
+    Stores predicted meta share, day 2 rate, tier, and likely adaptations.
+    After the tournament, actual results are backfilled for accuracy scoring.
+    """
+
+    __tablename__ = "archetype_predictions"
+    __table_args__ = (
+        UniqueConstraint(
+            "archetype_id",
+            "target_tournament_id",
+            name="uq_prediction_archetype_tournament",
+        ),
+    )
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Archetype identifier (normalized name)
+    archetype_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # Target tournament
+    target_tournament_id: Mapped[UUID] = mapped_column(
+        ForeignKey("tournaments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Predictions (ranges stored as JSON: {"low": 0.05, "mid": 0.08, "high": 0.12})
+    predicted_meta_share: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    predicted_day2_rate: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    predicted_tier: Mapped[str | None] = mapped_column(String(10), nullable=True)
+
+    # Expected adaptations and signals
+    # Format: [{"type": "tech", "description": "...", "cards": [...]}]
+    likely_adaptations: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    # Format: {"trending_in_jp": true, "jp_meta_share": 0.15, ...}
+    jp_signals: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Confidence and methodology
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    methodology: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Actuals (backfilled after tournament)
+    actual_meta_share: Mapped[float | None] = mapped_column(Float, nullable=True)
+    accuracy_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Relationships
+    target_tournament: Mapped["Tournament"] = relationship("Tournament")

--- a/apps/api/src/models/evolution_article.py
+++ b/apps/api/src/models/evolution_article.py
@@ -1,0 +1,75 @@
+"""EvolutionArticle model for archetype evolution content."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from src.models.evolution_article_snapshot import EvolutionArticleSnapshot
+    from src.models.lab_note import LabNote
+
+
+class EvolutionArticle(Base, TimestampMixin):
+    """Published article about an archetype's evolution over time.
+
+    Links to a series of snapshots to tell the story of how an archetype
+    adapted across tournaments. Can optionally link to a LabNote.
+    """
+
+    __tablename__ = "evolution_articles"
+
+    # Primary key
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+
+    # Archetype identifier (normalized name)
+    archetype_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # URL slug
+    slug: Mapped[str] = mapped_column(
+        String(255), nullable=False, unique=True, index=True
+    )
+
+    # Content
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    excerpt: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    introduction: Mapped[str | None] = mapped_column(Text, nullable=True)
+    conclusion: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Status and publishing
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="draft", index=True
+    )  # draft, review, published, archived
+    is_premium: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, index=True
+    )
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+
+    # Optional link to a lab note
+    lab_note_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("lab_notes.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Commerce links for recommended cards/products
+    # Format: [{"card_id": "sv4-6", "url": "...", "label": "Buy Charizard ex"}]
+    commerce_links: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+
+    # Engagement metrics
+    view_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    share_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Relationships
+    lab_note: Mapped["LabNote | None"] = relationship("LabNote")
+    article_snapshots: Mapped[list["EvolutionArticleSnapshot"]] = relationship(
+        "EvolutionArticleSnapshot",
+        back_populates="article",
+        cascade="all, delete-orphan",
+        order_by="EvolutionArticleSnapshot.position",
+    )

--- a/apps/api/src/models/evolution_article_snapshot.py
+++ b/apps/api/src/models/evolution_article_snapshot.py
@@ -1,0 +1,44 @@
+"""EvolutionArticleSnapshot join table linking articles to snapshots."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.db.base import Base
+
+if TYPE_CHECKING:
+    from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+    from src.models.evolution_article import EvolutionArticle
+
+
+class EvolutionArticleSnapshot(Base):
+    """Join table between EvolutionArticle and ArchetypeEvolutionSnapshot.
+
+    Uses a composite primary key of (article_id, snapshot_id) with an
+    ordering position for display.
+    """
+
+    __tablename__ = "evolution_article_snapshots"
+
+    # Composite primary key
+    article_id: Mapped[UUID] = mapped_column(
+        ForeignKey("evolution_articles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    snapshot_id: Mapped[UUID] = mapped_column(
+        ForeignKey("archetype_evolution_snapshots.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    # Display ordering
+    position: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Relationships
+    article: Mapped["EvolutionArticle"] = relationship(
+        "EvolutionArticle", back_populates="article_snapshots"
+    )
+    snapshot: Mapped["ArchetypeEvolutionSnapshot"] = relationship(
+        "ArchetypeEvolutionSnapshot", back_populates="article_snapshots"
+    )

--- a/apps/api/src/services/decklist_diff.py
+++ b/apps/api/src/services/decklist_diff.py
@@ -1,0 +1,169 @@
+"""Decklist diff engine for computing consensus lists and diffs.
+
+Pure logic module with no DB or async dependencies.
+Works at card_name level so reprints across sets are treated as the same card.
+"""
+
+from dataclasses import dataclass, field
+from statistics import median
+
+from src.data.card_reprints import CARD_REPRINTS
+
+
+@dataclass
+class CardChange:
+    """A single card change between two consensus lists."""
+
+    card_name: str
+    old_quantity: float
+    new_quantity: float
+
+    @property
+    def change(self) -> float:
+        return self.new_quantity - self.old_quantity
+
+
+@dataclass
+class DecklistDiffResult:
+    """Result of diffing two consensus decklists."""
+
+    added: list[CardChange] = field(default_factory=list)
+    removed: list[CardChange] = field(default_factory=list)
+    changed: list[CardChange] = field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.added or self.removed or self.changed)
+
+
+class DecklistDiffEngine:
+    """Engine for computing consensus decklists and diffs between snapshots.
+
+    Operates at the card_name level, normalizing reprints so the same card
+    printed across multiple sets is treated identically.
+    """
+
+    def normalize_card_name(self, card_entry: dict) -> str:
+        """Normalize a card entry to a canonical card name.
+
+        Checks the reprint mapping first (by card_id), then falls back
+        to the name field in the card entry.
+
+        Args:
+            card_entry: Dict with at least "card_id" and/or "name" keys.
+
+        Returns:
+            Canonical card name string.
+        """
+        card_id = card_entry.get("card_id", "")
+        if card_id and card_id in CARD_REPRINTS:
+            return CARD_REPRINTS[card_id]
+        return card_entry.get("name", card_id or "Unknown")
+
+    def _aggregate_decklist(self, decklist: list[dict]) -> dict[str, int]:
+        """Aggregate a decklist into {card_name: total_quantity}.
+
+        Handles cases where the same card appears multiple times in a list
+        (e.g., different prints of the same card).
+
+        Args:
+            decklist: List of card entries with card_id, name, quantity.
+
+        Returns:
+            Dict mapping canonical card name to total quantity.
+        """
+        aggregated: dict[str, int] = {}
+        for card in decklist:
+            name = self.normalize_card_name(card)
+            quantity = card.get("quantity", 0)
+            aggregated[name] = aggregated.get(name, 0) + quantity
+        return aggregated
+
+    def compute_consensus_list(
+        self,
+        decklists: list[list[dict]],
+        inclusion_threshold: float = 0.5,
+    ) -> list[dict]:
+        """Compute a consensus decklist from multiple decklists.
+
+        For each card, computes:
+        - inclusion_rate: fraction of decklists that include it
+        - quantity: median count across decklists that include it
+
+        Only cards above the inclusion threshold are included.
+
+        Args:
+            decklists: List of decklists, each being a list of card dicts.
+            inclusion_threshold: Minimum fraction of decklists a card must
+                appear in to be included in the consensus (default 0.5 = 50%).
+
+        Returns:
+            Sorted list of consensus card dicts with name, quantity, inclusion_rate.
+        """
+        if not decklists:
+            return []
+
+        total_lists = len(decklists)
+
+        # Aggregate each decklist and collect counts per card
+        card_counts: dict[str, list[int]] = {}
+        for decklist in decklists:
+            aggregated = self._aggregate_decklist(decklist)
+            for card_name, quantity in aggregated.items():
+                if card_name not in card_counts:
+                    card_counts[card_name] = []
+                card_counts[card_name].append(quantity)
+
+        # Build consensus
+        consensus: list[dict] = []
+        for card_name, counts in card_counts.items():
+            inclusion_rate = len(counts) / total_lists
+            if inclusion_rate >= inclusion_threshold:
+                median_count = median(counts)
+                consensus.append(
+                    {
+                        "name": card_name,
+                        "quantity": round(median_count),
+                        "inclusion_rate": round(inclusion_rate, 3),
+                    }
+                )
+
+        # Sort by inclusion rate (desc), then quantity (desc), then name
+        consensus.sort(key=lambda c: (-c["inclusion_rate"], -c["quantity"], c["name"]))
+        return consensus
+
+    def diff(
+        self,
+        old_consensus: list[dict],
+        new_consensus: list[dict],
+    ) -> DecklistDiffResult:
+        """Compute the diff between two consensus decklists.
+
+        Identifies cards that were added, removed, or had their quantity changed.
+
+        Args:
+            old_consensus: Previous consensus list.
+            new_consensus: Current consensus list.
+
+        Returns:
+            DecklistDiffResult with added, removed, and changed cards.
+        """
+        result = DecklistDiffResult()
+
+        old_map: dict[str, float] = {c["name"]: c["quantity"] for c in old_consensus}
+        new_map: dict[str, float] = {c["name"]: c["quantity"] for c in new_consensus}
+
+        all_cards = set(old_map.keys()) | set(new_map.keys())
+
+        for card_name in sorted(all_cards):
+            old_qty = old_map.get(card_name, 0)
+            new_qty = new_map.get(card_name, 0)
+
+            if old_qty == 0 and new_qty > 0:
+                result.added.append(CardChange(card_name, old_qty, new_qty))
+            elif old_qty > 0 and new_qty == 0:
+                result.removed.append(CardChange(card_name, old_qty, new_qty))
+            elif old_qty != new_qty:
+                result.changed.append(CardChange(card_name, old_qty, new_qty))
+
+        return result

--- a/apps/api/src/services/evolution_service.py
+++ b/apps/api/src/services/evolution_service.py
@@ -1,0 +1,354 @@
+"""Service for computing archetype evolution snapshots and adaptations.
+
+Orchestrates snapshot computation from tournament data and diff-based
+adaptation detection between consecutive snapshots.
+"""
+
+import logging
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.tournament import Tournament
+from src.models.tournament_placement import TournamentPlacement
+from src.services.decklist_diff import DecklistDiffEngine
+
+logger = logging.getLogger(__name__)
+
+
+class EvolutionError(Exception):
+    """Base exception for evolution service errors."""
+
+
+class EvolutionSnapshotNotFoundError(EvolutionError):
+    """Raised when a requested snapshot does not exist."""
+
+
+class EvolutionService:
+    """Service for computing and managing archetype evolution data."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.diff_engine = DecklistDiffEngine()
+
+    async def compute_tournament_snapshot(
+        self,
+        archetype: str,
+        tournament_id: UUID,
+    ) -> ArchetypeEvolutionSnapshot:
+        """Compute an evolution snapshot for an archetype at a tournament.
+
+        Queries all placements for the archetype in the given tournament,
+        computes performance metrics, and builds a consensus decklist.
+
+        Args:
+            archetype: Normalized archetype name.
+            tournament_id: Tournament to compute snapshot for.
+
+        Returns:
+            ArchetypeEvolutionSnapshot (not yet persisted).
+
+        Raises:
+            EvolutionError: If tournament not found or no placements.
+        """
+        # Get the tournament
+        tournament_result = await self.session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+        tournament = tournament_result.scalar_one_or_none()
+        if not tournament:
+            raise EvolutionError(f"Tournament {tournament_id} not found")
+
+        # Get placements for this archetype
+        placements_result = await self.session.execute(
+            select(TournamentPlacement).where(
+                TournamentPlacement.tournament_id == tournament_id,
+                TournamentPlacement.archetype == archetype,
+            )
+        )
+        placements = list(placements_result.scalars().all())
+
+        if not placements:
+            msg = f"No placements for '{archetype}' in tournament {tournament_id}"
+            raise EvolutionError(msg)
+
+        # Compute total placements in tournament for meta share
+        total_result = await self.session.execute(
+            select(TournamentPlacement).where(
+                TournamentPlacement.tournament_id == tournament_id,
+            )
+        )
+        total_placements = list(total_result.scalars().all())
+        total_count = len(total_placements)
+
+        # Performance metrics
+        deck_count = len(placements)
+        meta_share = deck_count / total_count if total_count > 0 else 0.0
+        best_placement = min(p.placement for p in placements)
+
+        # Top cut conversion (top 8 out of this archetype's entries)
+        top_cut = sum(1 for p in placements if p.placement <= 8)
+        top_cut_conversion = top_cut / deck_count if deck_count > 0 else 0.0
+
+        # Build consensus decklist from available decklists
+        decklists = [p.decklist for p in placements if p.decklist]
+        consensus_list = (
+            self.diff_engine.compute_consensus_list(decklists) if decklists else None
+        )
+
+        # Card usage stats
+        card_usage = self._compute_card_usage(decklists) if decklists else None
+
+        return ArchetypeEvolutionSnapshot(
+            id=uuid4(),
+            archetype=archetype,
+            tournament_id=tournament_id,
+            meta_share=round(meta_share, 4),
+            top_cut_conversion=round(top_cut_conversion, 4),
+            best_placement=best_placement,
+            deck_count=deck_count,
+            consensus_list=consensus_list,
+            card_usage=card_usage,
+        )
+
+    def _compute_card_usage(self, decklists: list[list[dict]]) -> dict:
+        """Compute per-card usage statistics across decklists.
+
+        Args:
+            decklists: List of decklists.
+
+        Returns:
+            Dict mapping card_name to usage stats.
+        """
+        if not decklists:
+            return {}
+
+        total = len(decklists)
+        card_data: dict[str, list[int]] = {}
+
+        for decklist in decklists:
+            aggregated = self.diff_engine._aggregate_decklist(decklist)
+            for card_name, quantity in aggregated.items():
+                if card_name not in card_data:
+                    card_data[card_name] = []
+                card_data[card_name].append(quantity)
+
+        usage: dict[str, dict] = {}
+        for card_name, counts in card_data.items():
+            avg_count = sum(counts) / len(counts)
+            inclusion_rate = len(counts) / total
+            usage[card_name] = {
+                "name": card_name,
+                "avg_count": round(avg_count, 2),
+                "inclusion_rate": round(inclusion_rate, 3),
+            }
+
+        return usage
+
+    async def compute_adaptations(
+        self,
+        from_snapshot_id: UUID,
+        to_snapshot_id: UUID,
+    ) -> list[Adaptation]:
+        """Compute adaptations between two consecutive snapshots.
+
+        Runs the diff engine on consensus lists and creates unclassified
+        Adaptation records for each change detected.
+
+        Args:
+            from_snapshot_id: Earlier snapshot ID.
+            to_snapshot_id: Later snapshot ID.
+
+        Returns:
+            List of Adaptation records (not yet persisted).
+
+        Raises:
+            EvolutionSnapshotNotFoundError: If either snapshot not found.
+        """
+        from_snapshot = await self._get_snapshot(from_snapshot_id)
+        to_snapshot = await self._get_snapshot(to_snapshot_id)
+
+        old_consensus = from_snapshot.consensus_list or []
+        new_consensus = to_snapshot.consensus_list or []
+
+        diff_result = self.diff_engine.diff(old_consensus, new_consensus)
+
+        adaptations: list[Adaptation] = []
+
+        for card_change in diff_result.added:
+            name = card_change.card_name
+            qty = card_change.new_quantity
+            adaptations.append(
+                Adaptation(
+                    id=uuid4(),
+                    snapshot_id=to_snapshot_id,
+                    type="tech",
+                    description=f"Added {name} (x{qty})",
+                    cards_added=[{"name": name, "quantity": qty}],
+                    source="diff",
+                )
+            )
+
+        for card_change in diff_result.removed:
+            name = card_change.card_name
+            qty = card_change.old_quantity
+            adaptations.append(
+                Adaptation(
+                    id=uuid4(),
+                    snapshot_id=to_snapshot_id,
+                    type="removal",
+                    description=f"Removed {name} (was x{qty})",
+                    cards_removed=[{"name": name, "quantity": qty}],
+                    source="diff",
+                )
+            )
+
+        for card_change in diff_result.changed:
+            name = card_change.card_name
+            old_qty = card_change.old_quantity
+            new_qty = card_change.new_quantity
+            direction = "increased" if card_change.change > 0 else "decreased"
+            adaptations.append(
+                Adaptation(
+                    id=uuid4(),
+                    snapshot_id=to_snapshot_id,
+                    type="consistency",
+                    description=(f"{name} {direction} from x{old_qty} to x{new_qty}"),
+                    cards_added=(
+                        [{"name": name, "quantity": new_qty}]
+                        if card_change.change > 0
+                        else None
+                    ),
+                    cards_removed=(
+                        [{"name": name, "quantity": old_qty}]
+                        if card_change.change < 0
+                        else None
+                    ),
+                    source="diff",
+                )
+            )
+
+        return adaptations
+
+    async def get_evolution_timeline(
+        self,
+        archetype: str,
+        limit: int = 10,
+    ) -> list[ArchetypeEvolutionSnapshot]:
+        """Get the evolution timeline for an archetype.
+
+        Args:
+            archetype: Normalized archetype name.
+            limit: Maximum number of snapshots to return.
+
+        Returns:
+            List of snapshots ordered by tournament date (most recent first).
+        """
+        query = (
+            select(ArchetypeEvolutionSnapshot)
+            .join(Tournament, ArchetypeEvolutionSnapshot.tournament_id == Tournament.id)
+            .where(ArchetypeEvolutionSnapshot.archetype == archetype)
+            .order_by(Tournament.date.desc())
+            .limit(limit)
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_previous_snapshot(
+        self,
+        archetype: str,
+        tournament_id: UUID,
+    ) -> ArchetypeEvolutionSnapshot | None:
+        """Get the snapshot immediately before the given tournament.
+
+        Args:
+            archetype: Normalized archetype name.
+            tournament_id: Current tournament ID (to find the one before it).
+
+        Returns:
+            Previous snapshot or None if this is the first.
+        """
+        # Get the current tournament's date
+        tournament_result = await self.session.execute(
+            select(Tournament.date).where(Tournament.id == tournament_id)
+        )
+        row = tournament_result.one_or_none()
+        if not row:
+            return None
+        current_date = row[0]
+
+        # Find the most recent snapshot before this tournament
+        query = (
+            select(ArchetypeEvolutionSnapshot)
+            .join(Tournament, ArchetypeEvolutionSnapshot.tournament_id == Tournament.id)
+            .where(
+                ArchetypeEvolutionSnapshot.archetype == archetype,
+                Tournament.date < current_date,
+            )
+            .order_by(Tournament.date.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def save_snapshot(self, snapshot: ArchetypeEvolutionSnapshot) -> None:
+        """Save a snapshot, handling upsert on unique constraint.
+
+        Args:
+            snapshot: The snapshot to save.
+
+        Raises:
+            SQLAlchemyError: If database operation fails.
+        """
+        try:
+            # Check for existing snapshot
+            existing_result = await self.session.execute(
+                select(ArchetypeEvolutionSnapshot).where(
+                    ArchetypeEvolutionSnapshot.archetype == snapshot.archetype,
+                    ArchetypeEvolutionSnapshot.tournament_id == snapshot.tournament_id,
+                )
+            )
+            existing = existing_result.scalar_one_or_none()
+
+            if existing:
+                # Update existing snapshot
+                existing.meta_share = snapshot.meta_share
+                existing.top_cut_conversion = snapshot.top_cut_conversion
+                existing.best_placement = snapshot.best_placement
+                existing.deck_count = snapshot.deck_count
+                existing.consensus_list = snapshot.consensus_list
+                existing.card_usage = snapshot.card_usage
+                existing.meta_context = snapshot.meta_context
+                await self.session.commit()
+            else:
+                self.session.add(snapshot)
+                await self.session.commit()
+
+        except IntegrityError:
+            await self.session.rollback()
+            logger.warning(
+                "Integrity error saving snapshot: archetype=%s, tournament=%s",
+                snapshot.archetype,
+                snapshot.tournament_id,
+            )
+            raise
+
+        except SQLAlchemyError:
+            await self.session.rollback()
+            raise
+
+    async def _get_snapshot(self, snapshot_id: UUID) -> ArchetypeEvolutionSnapshot:
+        """Get a snapshot by ID or raise EvolutionSnapshotNotFoundError."""
+        result = await self.session.execute(
+            select(ArchetypeEvolutionSnapshot).where(
+                ArchetypeEvolutionSnapshot.id == snapshot_id
+            )
+        )
+        snapshot = result.scalar_one_or_none()
+        if not snapshot:
+            raise EvolutionSnapshotNotFoundError(f"Snapshot {snapshot_id} not found")
+        return snapshot

--- a/apps/api/tests/test_decklist_diff.py
+++ b/apps/api/tests/test_decklist_diff.py
@@ -1,0 +1,302 @@
+"""Tests for the DecklistDiffEngine."""
+
+import pytest
+
+from src.services.decklist_diff import DecklistDiffEngine, DecklistDiffResult
+
+
+class TestNormalizeCardName:
+    """Tests for card name normalization and reprint handling."""
+
+    @pytest.fixture
+    def engine(self) -> DecklistDiffEngine:
+        return DecklistDiffEngine()
+
+    def test_normalizes_known_reprint_by_card_id(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Should return canonical name for a known reprint card_id."""
+        entry = {"card_id": "sv2-172", "name": "Boss's Orders (Ghetsis)", "quantity": 2}
+        assert engine.normalize_card_name(entry) == "Boss's Orders"
+
+    def test_falls_back_to_name_for_unknown_card_id(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Should use the name field when card_id is not in reprint mapping."""
+        entry = {"card_id": "sv7-144", "name": "Terapagos ex", "quantity": 3}
+        assert engine.normalize_card_name(entry) == "Terapagos ex"
+
+    def test_falls_back_to_card_id_when_no_name(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Should use card_id when name is missing and card_id is not in reprints."""
+        entry = {"card_id": "sv99-1", "quantity": 1}
+        assert engine.normalize_card_name(entry) == "sv99-1"
+
+    def test_returns_unknown_when_no_fields(self, engine: DecklistDiffEngine) -> None:
+        """Should return 'Unknown' when both card_id and name are missing."""
+        assert engine.normalize_card_name({}) == "Unknown"
+
+    def test_different_prints_normalize_to_same_name(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Should normalize different prints of Iono to the same canonical name."""
+        entries = [
+            {"card_id": "sv1-185", "name": "Iono", "quantity": 4},
+            {"card_id": "sv4pt5-80", "name": "Iono (alt art)", "quantity": 4},
+            {"card_id": "sv6-178", "name": "Iono", "quantity": 4},
+        ]
+        names = [engine.normalize_card_name(e) for e in entries]
+        assert all(n == "Iono" for n in names)
+
+
+class TestComputeConsensusList:
+    """Tests for consensus decklist computation."""
+
+    @pytest.fixture
+    def engine(self) -> DecklistDiffEngine:
+        return DecklistDiffEngine()
+
+    def test_empty_input_returns_empty(self, engine: DecklistDiffEngine) -> None:
+        """Should return empty list for no decklists."""
+        assert engine.compute_consensus_list([]) == []
+
+    def test_single_decklist_returns_all_cards(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Single decklist should include all cards at 100% inclusion."""
+        decklist = [
+            {"card_id": "sv7-144", "name": "Terapagos ex", "quantity": 3},
+            {"card_id": "sv1-185", "name": "Iono", "quantity": 4},
+        ]
+        result = engine.compute_consensus_list([decklist])
+        assert len(result) == 2
+        for card in result:
+            assert card["inclusion_rate"] == 1.0
+
+    def test_median_quantity_computed_correctly(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Should compute median count from decklists that include the card."""
+        decklists = [
+            [{"card_id": "a", "name": "CardA", "quantity": 4}],
+            [{"card_id": "a", "name": "CardA", "quantity": 2}],
+            [{"card_id": "a", "name": "CardA", "quantity": 3}],
+        ]
+        result = engine.compute_consensus_list(decklists)
+        card_a = next(c for c in result if c["name"] == "CardA")
+        assert card_a["quantity"] == 3  # median of [4, 2, 3] = 3
+
+    def test_inclusion_threshold_filters_cards(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Cards below the inclusion threshold should be excluded."""
+        decklists = [
+            [
+                {"card_id": "a", "name": "Common", "quantity": 4},
+                {"card_id": "b", "name": "Rare", "quantity": 1},
+            ],
+            [
+                {"card_id": "a", "name": "Common", "quantity": 4},
+            ],
+            [
+                {"card_id": "a", "name": "Common", "quantity": 4},
+            ],
+        ]
+        # Rare only in 1/3 = 33%, below 50% threshold
+        result = engine.compute_consensus_list(decklists, inclusion_threshold=0.5)
+        names = [c["name"] for c in result]
+        assert "Common" in names
+        assert "Rare" not in names
+
+    def test_inclusion_threshold_custom_value(self, engine: DecklistDiffEngine) -> None:
+        """Should respect custom inclusion threshold."""
+        decklists = [
+            [{"card_id": "a", "name": "CardA", "quantity": 2}],
+            [{"card_id": "a", "name": "CardA", "quantity": 2}],
+            [{"card_id": "b", "name": "CardB", "quantity": 1}],
+            [{"card_id": "b", "name": "CardB", "quantity": 1}],
+            [{"card_id": "c", "name": "CardC", "quantity": 1}],
+        ]
+        # CardA: 2/5=40%, CardB: 2/5=40%, CardC: 1/5=20%
+        result = engine.compute_consensus_list(decklists, inclusion_threshold=0.3)
+        names = [c["name"] for c in result]
+        assert "CardA" in names
+        assert "CardB" in names
+        assert "CardC" not in names
+
+    def test_reprints_treated_as_same_card(self, engine: DecklistDiffEngine) -> None:
+        """Different prints of the same card should be merged in consensus."""
+        decklists = [
+            [{"card_id": "sv1-185", "name": "Iono", "quantity": 4}],
+            [{"card_id": "sv4pt5-80", "name": "Iono (alt)", "quantity": 4}],
+            [{"card_id": "sv6-178", "name": "Iono (full art)", "quantity": 3}],
+        ]
+        result = engine.compute_consensus_list(decklists)
+        # All three should be normalized to "Iono"
+        iono_cards = [c for c in result if c["name"] == "Iono"]
+        assert len(iono_cards) == 1
+        assert iono_cards[0]["inclusion_rate"] == 1.0
+        assert iono_cards[0]["quantity"] == 4  # median of [4, 4, 3]
+
+    def test_same_card_different_entries_aggregated(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Multiple entries for the same card in one decklist should be summed."""
+        decklists = [
+            [
+                {"card_id": "sv1-185", "name": "Iono", "quantity": 2},
+                {"card_id": "sv4pt5-80", "name": "Iono (alt)", "quantity": 2},
+            ],
+        ]
+        result = engine.compute_consensus_list(decklists)
+        iono = next(c for c in result if c["name"] == "Iono")
+        assert iono["quantity"] == 4  # 2 + 2 from same decklist
+
+    def test_sorted_by_inclusion_then_quantity_then_name(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Results should be sorted by inclusion rate desc, quantity desc, name asc."""
+        decklists = [
+            [
+                {"card_id": "a", "name": "Zzz", "quantity": 4},
+                {"card_id": "b", "name": "Aaa", "quantity": 4},
+                {"card_id": "c", "name": "Mmm", "quantity": 1},
+            ],
+            [
+                {"card_id": "a", "name": "Zzz", "quantity": 4},
+                {"card_id": "b", "name": "Aaa", "quantity": 4},
+            ],
+        ]
+        result = engine.compute_consensus_list(decklists)
+        # Zzz and Aaa: 100% inclusion, qty 4 → sorted by name: Aaa, Zzz
+        # Mmm: 50% inclusion
+        assert result[0]["name"] == "Aaa"
+        assert result[1]["name"] == "Zzz"
+        assert result[2]["name"] == "Mmm"
+
+
+class TestDiff:
+    """Tests for diffing two consensus decklists."""
+
+    @pytest.fixture
+    def engine(self) -> DecklistDiffEngine:
+        return DecklistDiffEngine()
+
+    def test_identical_lists_produce_no_changes(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Diffing identical lists should produce no changes."""
+        consensus = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.8},
+        ]
+        result = engine.diff(consensus, consensus)
+        assert not result.has_changes
+        assert result.added == []
+        assert result.removed == []
+        assert result.changed == []
+
+    def test_detects_added_cards(self, engine: DecklistDiffEngine) -> None:
+        """Should detect cards present in new but not old."""
+        old = [{"name": "CardA", "quantity": 4, "inclusion_rate": 1.0}]
+        new = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.7},
+        ]
+        result = engine.diff(old, new)
+        assert len(result.added) == 1
+        assert result.added[0].card_name == "CardB"
+        assert result.added[0].new_quantity == 2
+
+    def test_detects_removed_cards(self, engine: DecklistDiffEngine) -> None:
+        """Should detect cards present in old but not new."""
+        old = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.7},
+        ]
+        new = [{"name": "CardA", "quantity": 4, "inclusion_rate": 1.0}]
+        result = engine.diff(old, new)
+        assert len(result.removed) == 1
+        assert result.removed[0].card_name == "CardB"
+        assert result.removed[0].old_quantity == 2
+
+    def test_detects_quantity_changes(self, engine: DecklistDiffEngine) -> None:
+        """Should detect cards whose quantity changed."""
+        old = [{"name": "CardA", "quantity": 4, "inclusion_rate": 1.0}]
+        new = [{"name": "CardA", "quantity": 3, "inclusion_rate": 1.0}]
+        result = engine.diff(old, new)
+        assert len(result.changed) == 1
+        assert result.changed[0].card_name == "CardA"
+        assert result.changed[0].change == -1
+
+    def test_complex_diff_with_all_change_types(
+        self, engine: DecklistDiffEngine
+    ) -> None:
+        """Should handle a mix of added, removed, and changed cards."""
+        old = [
+            {"name": "Stays", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "Removed", "quantity": 2, "inclusion_rate": 0.8},
+            {"name": "Changed", "quantity": 3, "inclusion_rate": 0.9},
+        ]
+        new = [
+            {"name": "Stays", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "Added", "quantity": 1, "inclusion_rate": 0.6},
+            {"name": "Changed", "quantity": 4, "inclusion_rate": 1.0},
+        ]
+        result = engine.diff(old, new)
+        assert len(result.added) == 1
+        assert result.added[0].card_name == "Added"
+        assert len(result.removed) == 1
+        assert result.removed[0].card_name == "Removed"
+        assert len(result.changed) == 1
+        assert result.changed[0].card_name == "Changed"
+        assert result.changed[0].change == 1
+
+    def test_empty_old_all_cards_are_added(self, engine: DecklistDiffEngine) -> None:
+        """Diffing from empty should show all new cards as added."""
+        new = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.8},
+        ]
+        result = engine.diff([], new)
+        assert len(result.added) == 2
+        assert result.removed == []
+
+    def test_empty_new_all_cards_are_removed(self, engine: DecklistDiffEngine) -> None:
+        """Diffing to empty should show all old cards as removed."""
+        old = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.8},
+        ]
+        result = engine.diff(old, [])
+        assert len(result.removed) == 2
+        assert result.added == []
+
+    def test_has_changes_property(self, engine: DecklistDiffEngine) -> None:
+        """has_changes should return True when there are any changes."""
+        result = DecklistDiffResult()
+        assert not result.has_changes
+
+        old = [{"name": "A", "quantity": 1, "inclusion_rate": 1.0}]
+        new = [{"name": "A", "quantity": 2, "inclusion_rate": 1.0}]
+        diff_result = engine.diff(old, new)
+        assert diff_result.has_changes
+
+
+class TestCardChange:
+    """Tests for CardChange dataclass."""
+
+    def test_change_property_positive(self) -> None:
+        """Change should be positive when quantity increased."""
+        from src.services.decklist_diff import CardChange
+
+        change = CardChange("Test", 2, 4)
+        assert change.change == 2
+
+    def test_change_property_negative(self) -> None:
+        """Change should be negative when quantity decreased."""
+        from src.services.decklist_diff import CardChange
+
+        change = CardChange("Test", 4, 2)
+        assert change.change == -2

--- a/apps/api/tests/test_evolution_service.py
+++ b/apps/api/tests/test_evolution_service.py
@@ -1,0 +1,442 @@
+"""Tests for the EvolutionService."""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.tournament import Tournament
+from src.models.tournament_placement import TournamentPlacement
+from src.services.evolution_service import (
+    EvolutionError,
+    EvolutionService,
+    EvolutionSnapshotNotFoundError,
+)
+
+_UNSET = object()
+
+
+def _make_execute_result(
+    *, scalar_one_or_none=_UNSET, scalars_all=_UNSET, one_or_none=_UNSET
+):
+    """Create a mock result from session.execute().
+
+    AsyncMock.execute returns a coroutine wrapping this MagicMock,
+    so chained calls like result.scalar_one_or_none() are sync.
+    """
+    mock_result = MagicMock()
+    if scalar_one_or_none is not _UNSET:
+        mock_result.scalar_one_or_none.return_value = scalar_one_or_none
+    if scalars_all is not _UNSET:
+        mock_result.scalars.return_value.all.return_value = scalars_all
+    if one_or_none is not _UNSET:
+        mock_result.one_or_none.return_value = one_or_none
+    return mock_result
+
+
+def _make_placement(
+    archetype: str = "Charizard ex",
+    placement: int = 1,
+    decklist: list[dict] | None = None,
+    tournament_id=None,
+) -> MagicMock:
+    """Helper to create a mock TournamentPlacement."""
+    mock = MagicMock(spec=TournamentPlacement)
+    mock.archetype = archetype
+    mock.placement = placement
+    mock.decklist = decklist
+    mock.tournament_id = tournament_id or uuid4()
+    return mock
+
+
+def _make_tournament(
+    tournament_id=None,
+    tier="major",
+    participant_count=256,
+    tournament_date=None,
+) -> MagicMock:
+    """Helper to create a mock Tournament."""
+    mock = MagicMock(spec=Tournament)
+    mock.id = tournament_id or uuid4()
+    mock.tier = tier
+    mock.participant_count = participant_count
+    mock.date = tournament_date or date(2026, 1, 15)
+    return mock
+
+
+class TestComputeTournamentSnapshot:
+    """Tests for snapshot computation from tournament data."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_session: AsyncMock) -> EvolutionService:
+        return EvolutionService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_tournament_not_found(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should raise EvolutionError when tournament doesn't exist."""
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=None
+        )
+
+        with pytest.raises(EvolutionError, match="not found"):
+            await service.compute_tournament_snapshot("Charizard ex", uuid4())
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_placements(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should raise EvolutionError when archetype has no placements."""
+        tournament = _make_tournament()
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=tournament),
+            _make_execute_result(scalars_all=[]),
+        ]
+
+        with pytest.raises(EvolutionError, match="No placements"):
+            await service.compute_tournament_snapshot("Charizard ex", tournament.id)
+
+    @pytest.mark.asyncio
+    async def test_computes_correct_metrics(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should compute meta_share, top_cut_conversion, best_placement."""
+        tournament = _make_tournament()
+        tid = tournament.id
+
+        charizard_placements = [
+            _make_placement("Charizard ex", 1, tournament_id=tid),
+            _make_placement("Charizard ex", 5, tournament_id=tid),
+            _make_placement("Charizard ex", 12, tournament_id=tid),
+            _make_placement("Charizard ex", 20, tournament_id=tid),
+        ]
+
+        all_placements = charizard_placements + [
+            _make_placement("Dragapult ex", 2, tournament_id=tid),
+            _make_placement("Dragapult ex", 3, tournament_id=tid),
+            _make_placement("Lugia VSTAR", 4, tournament_id=tid),
+            _make_placement("Gardevoir ex", 6, tournament_id=tid),
+            _make_placement("Gardevoir ex", 7, tournament_id=tid),
+            _make_placement("Raging Bolt ex", 8, tournament_id=tid),
+        ]
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=tournament),
+            _make_execute_result(scalars_all=charizard_placements),
+            _make_execute_result(scalars_all=all_placements),
+        ]
+
+        snapshot = await service.compute_tournament_snapshot("Charizard ex", tid)
+
+        assert snapshot.archetype == "Charizard ex"
+        assert snapshot.tournament_id == tid
+        assert snapshot.deck_count == 4
+        assert snapshot.meta_share == round(4 / 10, 4)
+        assert snapshot.best_placement == 1
+        # 2 of 4 in top 8 (placements 1 and 5)
+        assert snapshot.top_cut_conversion == round(2 / 4, 4)
+
+    @pytest.mark.asyncio
+    async def test_builds_consensus_from_decklists(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should compute consensus list from available decklists."""
+        tournament = _make_tournament()
+        tid = tournament.id
+
+        decklist_a = [
+            {"card_id": "a", "name": "CardA", "quantity": 4},
+            {"card_id": "b", "name": "CardB", "quantity": 3},
+        ]
+        decklist_b = [
+            {"card_id": "a", "name": "CardA", "quantity": 4},
+            {"card_id": "b", "name": "CardB", "quantity": 2},
+            {"card_id": "c", "name": "CardC", "quantity": 1},
+        ]
+
+        placements = [
+            _make_placement("Test", 1, decklist=decklist_a, tournament_id=tid),
+            _make_placement("Test", 2, decklist=decklist_b, tournament_id=tid),
+            _make_placement("Test", 3, decklist=None, tournament_id=tid),
+        ]
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=tournament),
+            _make_execute_result(scalars_all=placements),
+            _make_execute_result(scalars_all=placements),
+        ]
+
+        snapshot = await service.compute_tournament_snapshot("Test", tid)
+
+        assert snapshot.consensus_list is not None
+        names = [c["name"] for c in snapshot.consensus_list]
+        assert "CardA" in names
+        assert "CardB" in names
+        # CardC only in 1 of 2 decklists = 50%, meets threshold
+        assert "CardC" in names
+
+    @pytest.mark.asyncio
+    async def test_no_consensus_without_decklists(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should produce None consensus when no decklists available."""
+        tournament = _make_tournament()
+        tid = tournament.id
+
+        placements = [
+            _make_placement("Test", 1, decklist=None, tournament_id=tid),
+            _make_placement("Test", 5, decklist=None, tournament_id=tid),
+        ]
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=tournament),
+            _make_execute_result(scalars_all=placements),
+            _make_execute_result(scalars_all=placements),
+        ]
+
+        snapshot = await service.compute_tournament_snapshot("Test", tid)
+        assert snapshot.consensus_list is None
+        assert snapshot.card_usage is None
+
+
+class TestComputeAdaptations:
+    """Tests for adaptation computation between snapshots."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_session: AsyncMock) -> EvolutionService:
+        return EvolutionService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_snapshot_not_found(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should raise EvolutionSnapshotNotFoundError."""
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=None
+        )
+
+        with pytest.raises(EvolutionSnapshotNotFoundError):
+            await service.compute_adaptations(uuid4(), uuid4())
+
+    @pytest.mark.asyncio
+    async def test_detects_card_additions(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should create adaptation records for added cards."""
+        old_snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        old_snapshot.consensus_list = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+        ]
+
+        new_snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        new_snapshot.consensus_list = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.7},
+        ]
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=old_snapshot),
+            _make_execute_result(scalar_one_or_none=new_snapshot),
+        ]
+
+        adaptations = await service.compute_adaptations(uuid4(), uuid4())
+
+        assert len(adaptations) == 1
+        assert adaptations[0].type == "tech"
+        assert "CardB" in adaptations[0].description
+
+    @pytest.mark.asyncio
+    async def test_detects_card_removals(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should create adaptation records for removed cards."""
+        old_snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        old_snapshot.consensus_list = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+            {"name": "CardB", "quantity": 2, "inclusion_rate": 0.8},
+        ]
+
+        new_snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        new_snapshot.consensus_list = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+        ]
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=old_snapshot),
+            _make_execute_result(scalar_one_or_none=new_snapshot),
+        ]
+
+        adaptations = await service.compute_adaptations(uuid4(), uuid4())
+
+        assert len(adaptations) == 1
+        assert adaptations[0].type == "removal"
+        assert "CardB" in adaptations[0].description
+
+    @pytest.mark.asyncio
+    async def test_no_adaptations_for_identical_snapshots(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should return empty list when consensus lists are identical."""
+        consensus = [{"name": "CardA", "quantity": 4, "inclusion_rate": 1.0}]
+
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.consensus_list = consensus
+
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=snapshot
+        )
+
+        adaptations = await service.compute_adaptations(uuid4(), uuid4())
+        assert adaptations == []
+
+    @pytest.mark.asyncio
+    async def test_handles_null_consensus_lists(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should handle snapshots with None consensus lists."""
+        old_snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        old_snapshot.consensus_list = None
+
+        new_snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        new_snapshot.consensus_list = [
+            {"name": "CardA", "quantity": 4, "inclusion_rate": 1.0},
+        ]
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=old_snapshot),
+            _make_execute_result(scalar_one_or_none=new_snapshot),
+        ]
+
+        adaptations = await service.compute_adaptations(uuid4(), uuid4())
+        assert len(adaptations) == 1
+        assert adaptations[0].type == "tech"
+
+
+class TestSaveSnapshot:
+    """Tests for snapshot persistence."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_session: AsyncMock) -> EvolutionService:
+        return EvolutionService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_creates_new_snapshot(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should add new snapshot when none exists."""
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=None
+        )
+
+        snapshot = ArchetypeEvolutionSnapshot(
+            id=uuid4(),
+            archetype="Charizard ex",
+            tournament_id=uuid4(),
+            deck_count=5,
+        )
+
+        await service.save_snapshot(snapshot)
+        mock_session.add.assert_called_once_with(snapshot)
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_snapshot(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should update fields when snapshot already exists."""
+        existing = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=existing
+        )
+
+        snapshot = ArchetypeEvolutionSnapshot(
+            id=uuid4(),
+            archetype="Charizard ex",
+            tournament_id=uuid4(),
+            meta_share=0.15,
+            deck_count=8,
+            best_placement=2,
+        )
+
+        await service.save_snapshot(snapshot)
+        assert existing.meta_share == 0.15
+        assert existing.deck_count == 8
+        mock_session.commit.assert_called_once()
+
+
+class TestGetEvolutionTimeline:
+    """Tests for timeline queries."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_session: AsyncMock) -> EvolutionService:
+        return EvolutionService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_returns_snapshots_ordered_by_date(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should return snapshots in reverse chronological order."""
+        snapshots = [MagicMock(spec=ArchetypeEvolutionSnapshot) for _ in range(3)]
+
+        mock_session.execute.return_value = _make_execute_result(scalars_all=snapshots)
+
+        result = await service.get_evolution_timeline("Charizard ex", limit=10)
+        assert len(result) == 3
+        mock_session.execute.assert_called_once()
+
+
+class TestGetPreviousSnapshot:
+    """Tests for finding previous snapshots."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_session: AsyncMock) -> EvolutionService:
+        return EvolutionService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_previous(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should return None when tournament not found."""
+        mock_session.execute.return_value = _make_execute_result(one_or_none=None)
+
+        result = await service.get_previous_snapshot("Charizard ex", uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_previous_snapshot(
+        self, service: EvolutionService, mock_session: AsyncMock
+    ) -> None:
+        """Should return the most recent snapshot before the tournament."""
+        previous = MagicMock(spec=ArchetypeEvolutionSnapshot)
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(one_or_none=(date(2026, 1, 15),)),
+            _make_execute_result(scalar_one_or_none=previous),
+        ]
+
+        result = await service.get_previous_snapshot("Charizard ex", uuid4())
+        assert result is previous


### PR DESCRIPTION
## Summary
- Add 5 new database models for archetype evolution tracking (ArchetypeEvolutionSnapshot, Adaptation, ArchetypePrediction, EvolutionArticle, EvolutionArticleSnapshot)
- Implement DecklistDiffEngine for computing consensus decklists and diffing between tournament snapshots, with card reprint normalization
- Implement EvolutionService for orchestrating snapshot computation, adaptation detection, and timeline queries
- Integrate evolution snapshot computation into the scrape pipeline for qualifying tournaments (major/premier tier or 64+ participants)

## Issues Addressed
- #272: [3A.1] Evolution Database Models + Migration
- #273: [3A.2] Decklist Diff Engine
- #274: [3A.3] Evolution Service
- #275: [3A.4] Pipeline Integration — Snapshot Collection

## Changes
### New Files (11)
- `src/models/archetype_evolution_snapshot.py` — Snapshot model with performance metrics and consensus list
- `src/models/adaptation.py` — Adaptation model for tracking card changes between snapshots
- `src/models/archetype_prediction.py` — Prediction model for forecasting archetype performance
- `src/models/evolution_article.py` — Article model for evolution content
- `src/models/evolution_article_snapshot.py` — Join table linking articles to snapshots
- `src/data/card_reprints.py` — Reprint mapping for normalizing cards across sets
- `src/services/decklist_diff.py` — Pure logic diff engine (no DB dependencies)
- `src/services/evolution_service.py` — Async service for evolution computation
- `alembic/versions/20260204_0001_015_add_evolution_tables.py` — Migration with upgrade/downgrade
- `tests/test_decklist_diff.py` — 23 unit tests for diff engine
- `tests/test_evolution_service.py` — 15 unit tests for evolution service

### Modified Files (3)
- `src/models/__init__.py` — Register new models
- `alembic/env.py` — Import new models for autogenerate
- `src/pipelines/scrape_limitless.py` — Add evolution trigger after tournament processing

## Testing
- [x] 38 new unit tests passing
- [x] All 692 existing tests still passing
- [x] ruff check passing
- [x] ruff format passing
- [x] ty type check passing
- [x] Pre-commit hooks passing

Closes #272, closes #273, closes #274, closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)