### PR TITLE
feat: AI services + TCGdex URL encoding fix (#267, #276, #277, #279)

### DIFF
--- a/apps/api/src/clients/tcgdex.py
+++ b/apps/api/src/clients/tcgdex.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import date
 from typing import Any, Self
+from urllib.parse import quote
 
 import httpx
 
@@ -307,7 +308,8 @@ class TCGdexClient:
         Returns:
             Full card details.
         """
-        data = await self._get(f"/{language}/cards/{card_id}")
+        encoded_id = quote(card_id, safe="")
+        data = await self._get(f"/{language}/cards/{encoded_id}")
         return TCGdexCard.from_dict(data)
 
     async def fetch_cards_for_set(

--- a/apps/api/src/services/adaptation_classifier.py
+++ b/apps/api/src/services/adaptation_classifier.py
@@ -1,0 +1,259 @@
+"""AI-powered adaptation classifier and meta context generator.
+
+Uses Claude to classify adaptations and generate human-readable
+meta context explanations for archetype evolution snapshots.
+"""
+
+import json
+import logging
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.clients.claude import MODEL_HAIKU, MODEL_SONNET, ClaudeClient, ClaudeError
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.meta_snapshot import MetaSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class AdaptationClassifierError(Exception):
+    """Error during adaptation classification."""
+
+
+class AdaptationClassifier:
+    """Classifies adaptations and generates meta context using Claude."""
+
+    def __init__(self, session: AsyncSession, claude: ClaudeClient) -> None:
+        self.session = session
+        self.claude = claude
+
+    async def classify(
+        self,
+        adaptation: Adaptation,
+        meta_context: dict | None = None,
+    ) -> Adaptation:
+        """Classify an adaptation using Claude Haiku.
+
+        Updates the adaptation's type, description, prevalence, confidence,
+        and target_archetype fields based on AI analysis.
+
+        Args:
+            adaptation: The adaptation to classify.
+            meta_context: Optional dict with current meta info (top archetypes,
+                recent trends) to help Claude understand the context.
+
+        Returns:
+            The updated Adaptation with classification fields populated.
+
+        Raises:
+            AdaptationClassifierError: If classification fails.
+        """
+        system_prompt = (
+            "You are a Pokemon TCG meta analyst. Classify the following "
+            "card change (adaptation) in a competitive deck.\n\n"
+            "Respond with JSON containing:\n"
+            '- "type": one of "tech", "consistency", "engine", "removal"\n'
+            "  - tech: a card added to counter a specific matchup\n"
+            "  - consistency: a count change to improve draw/search\n"
+            "  - engine: a core combo piece change\n"
+            "  - removal: a card dropped from the list\n"
+            '- "description": 1-2 sentence explanation of why this change '
+            "was made\n"
+            '- "target_archetype": if type is "tech", which archetype '
+            "this targets (or null)\n"
+            '- "confidence": float 0.0-1.0 for how confident this '
+            "classification is\n"
+            '- "prevalence": float 0.0-1.0 for how widespread this '
+            "change is in the meta"
+        )
+
+        change_info = {
+            "cards_added": adaptation.cards_added,
+            "cards_removed": adaptation.cards_removed,
+            "current_type": adaptation.type,
+            "current_description": adaptation.description,
+        }
+
+        user_prompt = f"Card change:\n{json.dumps(change_info, indent=2)}"
+        if meta_context:
+            user_prompt += (
+                f"\n\nCurrent meta context:\n{json.dumps(meta_context, indent=2)}"
+            )
+
+        try:
+            result = await self.claude.classify(
+                system=system_prompt,
+                user=user_prompt,
+                model=MODEL_HAIKU,
+                max_tokens=512,
+            )
+
+            adaptation.type = result.get("type", adaptation.type)
+            adaptation.description = result.get("description", adaptation.description)
+            adaptation.confidence = result.get("confidence")
+            adaptation.prevalence = result.get("prevalence")
+            adaptation.target_archetype = result.get("target_archetype")
+            adaptation.source = "claude"
+
+            return adaptation
+
+        except ClaudeError as e:
+            raise AdaptationClassifierError(
+                f"Failed to classify adaptation: {e}"
+            ) from e
+
+    async def generate_meta_context(
+        self,
+        snapshot: ArchetypeEvolutionSnapshot,
+        adaptations: list[Adaptation],
+        meta_snapshot: MetaSnapshot | None = None,
+    ) -> str:
+        """Generate a human-readable meta context for a snapshot.
+
+        Produces a 2-3 sentence explanation of why the archetype
+        evolved this way, considering the current meta landscape.
+
+        Args:
+            snapshot: The evolution snapshot to explain.
+            adaptations: Adaptations detected for this snapshot.
+            meta_snapshot: Optional current meta snapshot for context.
+
+        Returns:
+            A 2-3 sentence meta context string.
+
+        Raises:
+            AdaptationClassifierError: If generation fails.
+        """
+        system_prompt = (
+            "You are a Pokemon TCG meta analyst writing for competitive "
+            "players. Generate a concise 2-3 sentence explanation of why "
+            "this archetype evolved this way at this tournament.\n\n"
+            "Focus on:\n"
+            "- What meta threats drove the changes\n"
+            "- How the adaptations improve specific matchups\n"
+            "- Any broader meta trends reflected\n\n"
+            "Write in present tense, analytical tone. "
+            "Do not use markdown formatting."
+        )
+
+        snapshot_data = {
+            "archetype": snapshot.archetype,
+            "meta_share": snapshot.meta_share,
+            "top_cut_conversion": snapshot.top_cut_conversion,
+            "best_placement": snapshot.best_placement,
+            "deck_count": snapshot.deck_count,
+        }
+
+        adaptations_data = []
+        for a in adaptations:
+            adaptations_data.append(
+                {
+                    "type": a.type,
+                    "description": a.description,
+                    "cards_added": a.cards_added,
+                    "cards_removed": a.cards_removed,
+                    "target_archetype": a.target_archetype,
+                }
+            )
+
+        meta_data = None
+        if meta_snapshot:
+            top_10 = dict(
+                sorted(
+                    meta_snapshot.archetype_shares.items(),
+                    key=lambda x: x[1],
+                    reverse=True,
+                )[:10]
+            )
+            meta_data = {
+                "top_archetypes": top_10,
+                "jp_signals": meta_snapshot.jp_signals,
+                "trends": meta_snapshot.trends,
+            }
+
+        user_prompt = (
+            f"Snapshot:\n{json.dumps(snapshot_data, indent=2)}\n\n"
+            f"Adaptations:\n{json.dumps(adaptations_data, indent=2)}"
+        )
+        if meta_data:
+            user_prompt += f"\n\nMeta landscape:\n{json.dumps(meta_data, indent=2)}"
+
+        try:
+            return await self.claude.generate(
+                system=system_prompt,
+                user=user_prompt,
+                model=MODEL_SONNET,
+                max_tokens=512,
+            )
+        except ClaudeError as e:
+            raise AdaptationClassifierError(
+                f"Failed to generate meta context: {e}"
+            ) from e
+
+    async def classify_and_contextualize(
+        self,
+        snapshot_id: UUID,
+    ) -> str | None:
+        """Classify all adaptations for a snapshot and generate meta context.
+
+        Convenience method that loads the snapshot and its adaptations,
+        classifies each, then generates an overall meta context.
+
+        Args:
+            snapshot_id: The snapshot to process.
+
+        Returns:
+            Generated meta context string, or None if no adaptations.
+        """
+        result = await self.session.execute(
+            select(ArchetypeEvolutionSnapshot).where(
+                ArchetypeEvolutionSnapshot.id == snapshot_id
+            )
+        )
+        snapshot = result.scalar_one_or_none()
+        if not snapshot:
+            return None
+
+        result = await self.session.execute(
+            select(Adaptation).where(Adaptation.snapshot_id == snapshot_id)
+        )
+        adaptations = list(result.scalars().all())
+
+        if not adaptations:
+            return None
+
+        # Get latest meta snapshot for context
+        result = await self.session.execute(
+            select(MetaSnapshot).order_by(MetaSnapshot.snapshot_date.desc()).limit(1)
+        )
+        meta_snapshot = result.scalar_one_or_none()
+
+        meta_ctx = None
+        if meta_snapshot:
+            top_10 = dict(
+                sorted(
+                    meta_snapshot.archetype_shares.items(),
+                    key=lambda x: x[1],
+                    reverse=True,
+                )[:10]
+            )
+            meta_ctx = {
+                "top_archetypes": top_10,
+                "jp_signals": meta_snapshot.jp_signals,
+            }
+
+        # Classify each adaptation
+        for adaptation in adaptations:
+            await self.classify(adaptation, meta_context=meta_ctx)
+
+        # Generate meta context
+        context = await self.generate_meta_context(snapshot, adaptations, meta_snapshot)
+
+        # Save to snapshot
+        snapshot.meta_context = context
+        await self.session.commit()
+
+        return context

--- a/apps/api/src/services/evolution_article_generator.py
+++ b/apps/api/src/services/evolution_article_generator.py
@@ -1,0 +1,301 @@
+"""AI-powered evolution article generator.
+
+Generates narrative articles about archetype evolution by combining
+snapshot data, adaptations, and predictions into readable content.
+"""
+
+import logging
+import re
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.clients.claude import MODEL_SONNET, ClaudeClient, ClaudeError
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.evolution_article import EvolutionArticle
+from src.models.evolution_article_snapshot import EvolutionArticleSnapshot
+from src.models.lab_note import LabNote
+from src.models.tournament import Tournament
+
+logger = logging.getLogger(__name__)
+
+
+class ArticleGeneratorError(Exception):
+    """Error during article generation."""
+
+
+class EvolutionArticleGenerator:
+    """Generates and publishes evolution articles using Claude."""
+
+    def __init__(self, session: AsyncSession, claude: ClaudeClient) -> None:
+        self.session = session
+        self.claude = claude
+
+    async def generate_article(
+        self,
+        archetype: str,
+        limit: int = 6,
+    ) -> EvolutionArticle:
+        """Generate an evolution article for an archetype.
+
+        Loads snapshots, adaptations, and predictions, then uses Claude
+        to generate introduction and conclusion narrative sections.
+
+        Args:
+            archetype: Normalized archetype name.
+            limit: Maximum number of snapshots to include.
+
+        Returns:
+            An EvolutionArticle (not yet persisted).
+
+        Raises:
+            ArticleGeneratorError: If generation fails.
+        """
+        # Load snapshots ordered by tournament date
+        snapshots = await self._load_snapshots(archetype, limit)
+        if not snapshots:
+            raise ArticleGeneratorError(
+                f"No snapshots found for archetype '{archetype}'"
+            )
+
+        # Load adaptations for all snapshots
+        snapshot_ids = [s.id for s in snapshots]
+        adaptations = await self._load_adaptations(snapshot_ids)
+
+        # Load prediction if available
+        prediction = await self._load_latest_prediction(archetype)
+
+        # Generate narrative content
+        try:
+            narrative = await self._generate_narrative(
+                archetype, snapshots, adaptations, prediction
+            )
+        except ClaudeError as e:
+            raise ArticleGeneratorError(
+                f"Failed to generate article narrative: {e}"
+            ) from e
+
+        # Create article
+        slug = self._generate_slug(archetype)
+        title = narrative.get("title", f"{archetype} Evolution Analysis")
+        article = EvolutionArticle(
+            id=uuid4(),
+            archetype_id=archetype,
+            slug=slug,
+            title=title,
+            excerpt=narrative.get("excerpt"),
+            introduction=narrative.get("introduction"),
+            conclusion=narrative.get("conclusion"),
+            status="draft",
+        )
+
+        return article
+
+    async def link_snapshots(
+        self,
+        article: EvolutionArticle,
+        snapshot_ids: list[UUID],
+    ) -> list[EvolutionArticleSnapshot]:
+        """Link snapshots to an article via the junction table.
+
+        Args:
+            article: The article to link snapshots to.
+            snapshot_ids: Ordered list of snapshot IDs.
+
+        Returns:
+            List of EvolutionArticleSnapshot join records.
+        """
+        links = []
+        for position, snapshot_id in enumerate(snapshot_ids):
+            link = EvolutionArticleSnapshot(
+                article_id=article.id,
+                snapshot_id=snapshot_id,
+                position=position,
+            )
+            links.append(link)
+        return links
+
+    async def publish_article(self, article_id: UUID) -> LabNote | None:
+        """Publish an article and create a summary Lab Note.
+
+        Sets the article status to 'published' and creates a
+        corresponding LabNote of type 'archetype_evolution'.
+
+        Args:
+            article_id: The article to publish.
+
+        Returns:
+            The created LabNote, or None if article not found.
+
+        Raises:
+            ArticleGeneratorError: If publishing fails.
+        """
+        result = await self.session.execute(
+            select(EvolutionArticle).where(EvolutionArticle.id == article_id)
+        )
+        article = result.scalar_one_or_none()
+        if not article:
+            return None
+
+        now = datetime.now(UTC)
+
+        # Update article status
+        article.status = "published"
+        article.published_at = now
+
+        # Create summary Lab Note
+        content = self._build_lab_note_content(article)
+        lab_note = LabNote(
+            id=uuid4(),
+            slug=f"evolution-{article.slug}",
+            note_type="archetype_evolution",
+            title=article.title,
+            summary=article.excerpt,
+            content=content,
+            status="published",
+            is_published=True,
+            published_at=now,
+            tags=[article.archetype_id, "evolution"],
+            related_content={"archetypes": [article.archetype_id]},
+        )
+
+        self.session.add(lab_note)
+        article.lab_note_id = lab_note.id
+        await self.session.commit()
+
+        return lab_note
+
+    async def _load_snapshots(
+        self, archetype: str, limit: int
+    ) -> list[ArchetypeEvolutionSnapshot]:
+        """Load snapshots ordered by tournament date."""
+        query = (
+            select(ArchetypeEvolutionSnapshot)
+            .join(
+                Tournament,
+                ArchetypeEvolutionSnapshot.tournament_id == Tournament.id,
+            )
+            .where(ArchetypeEvolutionSnapshot.archetype == archetype)
+            .order_by(Tournament.date.desc())
+            .limit(limit)
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def _load_adaptations(self, snapshot_ids: list[UUID]) -> list[Adaptation]:
+        """Load adaptations for the given snapshots."""
+        if not snapshot_ids:
+            return []
+        result = await self.session.execute(
+            select(Adaptation).where(Adaptation.snapshot_id.in_(snapshot_ids))
+        )
+        return list(result.scalars().all())
+
+    async def _load_latest_prediction(
+        self, archetype: str
+    ) -> ArchetypePrediction | None:
+        """Load the most recent prediction for the archetype."""
+        result = await self.session.execute(
+            select(ArchetypePrediction)
+            .where(ArchetypePrediction.archetype_id == archetype)
+            .order_by(ArchetypePrediction.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def _generate_narrative(
+        self,
+        archetype: str,
+        snapshots: list[ArchetypeEvolutionSnapshot],
+        adaptations: list[Adaptation],
+        prediction: ArchetypePrediction | None,
+    ) -> dict:
+        """Use Claude to generate article narrative sections."""
+        system_prompt = (
+            "You are a Pokemon TCG meta analyst writing an evolution "
+            "article for competitive players. Generate engaging, "
+            "analytical content.\n\n"
+            "Respond with JSON containing:\n"
+            '- "title": compelling article title (max 100 chars)\n'
+            '- "excerpt": 1-2 sentence preview (max 200 chars)\n'
+            '- "introduction": 2-3 paragraph intro covering the '
+            "archetype's recent trajectory\n"
+            '- "conclusion": 1-2 paragraph conclusion with outlook '
+            "and recommendations"
+        )
+
+        snapshot_data = []
+        for s in snapshots:
+            snapshot_data.append(
+                {
+                    "archetype": s.archetype,
+                    "meta_share": s.meta_share,
+                    "top_cut_conversion": s.top_cut_conversion,
+                    "best_placement": s.best_placement,
+                    "deck_count": s.deck_count,
+                    "meta_context": s.meta_context,
+                }
+            )
+
+        adaptation_data = []
+        for a in adaptations:
+            adaptation_data.append(
+                {
+                    "type": a.type,
+                    "description": a.description,
+                    "cards_added": a.cards_added,
+                    "cards_removed": a.cards_removed,
+                }
+            )
+
+        import json
+
+        user_prompt = (
+            f"Write an evolution article for {archetype}.\n\n"
+            f"Snapshots (most recent first):\n"
+            f"{json.dumps(snapshot_data, indent=2)}\n\n"
+            f"Adaptations:\n{json.dumps(adaptation_data, indent=2)}"
+        )
+
+        if prediction:
+            pred_data = {
+                "predicted_tier": prediction.predicted_tier,
+                "predicted_meta_share": prediction.predicted_meta_share,
+                "methodology": prediction.methodology,
+            }
+            user_prompt += f"\n\nPrediction:\n{json.dumps(pred_data, indent=2)}"
+
+        result = await self.claude.classify(
+            system=system_prompt,
+            user=user_prompt,
+            model=MODEL_SONNET,
+            max_tokens=2048,
+        )
+
+        return result
+
+    def _generate_slug(self, archetype: str) -> str:
+        """Generate a URL slug for the article."""
+        base = archetype.lower()
+        base = re.sub(r"[^a-z0-9\s-]", "", base)
+        base = re.sub(r"[\s]+", "-", base).strip("-")
+        timestamp = datetime.now(UTC).strftime("%Y%m%d")
+        return f"{base}-evolution-{timestamp}"
+
+    def _build_lab_note_content(self, article: EvolutionArticle) -> str:
+        """Build markdown content for the summary Lab Note."""
+        parts = [f"# {article.title}\n"]
+
+        if article.introduction:
+            parts.append(article.introduction)
+            parts.append("")
+
+        if article.conclusion:
+            parts.append("## Outlook\n")
+            parts.append(article.conclusion)
+
+        return "\n".join(parts)

--- a/apps/api/src/services/prediction_engine.py
+++ b/apps/api/src/services/prediction_engine.py
@@ -1,0 +1,266 @@
+"""AI-powered prediction engine for archetype performance forecasting.
+
+Combines historical evolution data, JP meta signals, and upcoming set
+releases to predict archetype performance at future tournaments.
+"""
+
+import json
+import logging
+from datetime import date
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.clients.claude import MODEL_SONNET, ClaudeClient, ClaudeError
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.meta_snapshot import MetaSnapshot
+from src.models.set import Set
+from src.models.tournament import Tournament
+
+logger = logging.getLogger(__name__)
+
+
+class PredictionEngineError(Exception):
+    """Error during prediction generation."""
+
+
+class PredictionEngine:
+    """Generates and scores archetype performance predictions."""
+
+    def __init__(self, session: AsyncSession, claude: ClaudeClient) -> None:
+        self.session = session
+        self.claude = claude
+
+    async def predict(
+        self,
+        archetype: str,
+        target_tournament_id: UUID,
+    ) -> ArchetypePrediction:
+        """Generate a prediction for an archetype at an upcoming tournament.
+
+        Loads recent snapshots, JP meta data, and upcoming set releases
+        to build context, then uses Claude Sonnet to generate predictions.
+
+        Args:
+            archetype: Normalized archetype name.
+            target_tournament_id: Tournament to predict for.
+
+        Returns:
+            An ArchetypePrediction (not yet persisted).
+
+        Raises:
+            PredictionEngineError: If prediction fails.
+        """
+        # Load last 6 snapshots for trajectory
+        snapshots = await self._load_recent_snapshots(archetype, limit=6)
+
+        # Get target tournament info
+        result = await self.session.execute(
+            select(Tournament).where(Tournament.id == target_tournament_id)
+        )
+        tournament = result.scalar_one_or_none()
+        if not tournament:
+            raise PredictionEngineError(f"Tournament {target_tournament_id} not found")
+
+        # Get latest meta snapshot for JP signals
+        meta_snapshot = await self._get_latest_meta_snapshot()
+
+        # Check for new set releases before tournament date
+        new_sets = await self._get_upcoming_sets(tournament.date)
+
+        # Build context for Claude
+        context = self._build_prediction_context(
+            archetype, snapshots, meta_snapshot, new_sets, tournament
+        )
+
+        # Generate prediction via Claude
+        try:
+            prediction_data = await self._generate_prediction(archetype, context)
+        except ClaudeError as e:
+            raise PredictionEngineError(f"Failed to generate prediction: {e}") from e
+
+        return ArchetypePrediction(
+            id=uuid4(),
+            archetype_id=archetype,
+            target_tournament_id=target_tournament_id,
+            predicted_meta_share=prediction_data.get("predicted_meta_share"),
+            predicted_day2_rate=prediction_data.get("predicted_day2_rate"),
+            predicted_tier=prediction_data.get("predicted_tier"),
+            likely_adaptations=prediction_data.get("likely_adaptations"),
+            jp_signals=prediction_data.get("jp_signals"),
+            confidence=prediction_data.get("confidence"),
+            methodology=prediction_data.get("methodology"),
+        )
+
+    async def score_prediction(self, prediction_id: UUID) -> None:
+        """Score a prediction after the tournament has occurred.
+
+        Computes accuracy by comparing predicted vs actual meta share.
+
+        Args:
+            prediction_id: The prediction to score.
+
+        Raises:
+            PredictionEngineError: If scoring fails.
+        """
+        result = await self.session.execute(
+            select(ArchetypePrediction).where(ArchetypePrediction.id == prediction_id)
+        )
+        prediction = result.scalar_one_or_none()
+        if not prediction:
+            raise PredictionEngineError(f"Prediction {prediction_id} not found")
+
+        # Find the actual snapshot for this archetype at the tournament
+        result = await self.session.execute(
+            select(ArchetypeEvolutionSnapshot).where(
+                ArchetypeEvolutionSnapshot.archetype == prediction.archetype_id,
+                ArchetypeEvolutionSnapshot.tournament_id
+                == prediction.target_tournament_id,
+            )
+        )
+        snapshot = result.scalar_one_or_none()
+        if not snapshot:
+            logger.warning(
+                "No snapshot found for scoring prediction %s",
+                prediction_id,
+            )
+            return
+
+        prediction.actual_meta_share = snapshot.meta_share
+
+        # Compute accuracy score
+        if prediction.predicted_meta_share and prediction.actual_meta_share is not None:
+            mid = prediction.predicted_meta_share.get("mid", 0)
+            if mid > 0:
+                error = abs(prediction.actual_meta_share - mid) / mid
+                prediction.accuracy_score = round(max(0, 1.0 - error), 4)
+
+        await self.session.commit()
+
+    async def _load_recent_snapshots(
+        self, archetype: str, limit: int = 6
+    ) -> list[ArchetypeEvolutionSnapshot]:
+        """Load recent snapshots ordered by tournament date."""
+        query = (
+            select(ArchetypeEvolutionSnapshot)
+            .join(
+                Tournament,
+                ArchetypeEvolutionSnapshot.tournament_id == Tournament.id,
+            )
+            .where(ArchetypeEvolutionSnapshot.archetype == archetype)
+            .order_by(Tournament.date.desc())
+            .limit(limit)
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def _get_latest_meta_snapshot(self) -> MetaSnapshot | None:
+        """Get the most recent meta snapshot."""
+        result = await self.session.execute(
+            select(MetaSnapshot).order_by(MetaSnapshot.snapshot_date.desc()).limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def _get_upcoming_sets(self, before_date: date) -> list[Set]:
+        """Get sets released recently (within 30 days before tournament)."""
+        from datetime import timedelta
+
+        cutoff = before_date - timedelta(days=30)
+        result = await self.session.execute(
+            select(Set).where(
+                Set.release_date >= cutoff,
+                Set.release_date <= before_date,
+            )
+        )
+        return list(result.scalars().all())
+
+    def _build_prediction_context(
+        self,
+        archetype: str,
+        snapshots: list[ArchetypeEvolutionSnapshot],
+        meta_snapshot: MetaSnapshot | None,
+        new_sets: list[Set],
+        tournament: Tournament,
+    ) -> dict:
+        """Build the context dict for Claude's prediction prompt."""
+        trajectory = []
+        for s in snapshots:
+            trajectory.append(
+                {
+                    "meta_share": s.meta_share,
+                    "top_cut_conversion": s.top_cut_conversion,
+                    "best_placement": s.best_placement,
+                    "deck_count": s.deck_count,
+                }
+            )
+
+        context: dict = {
+            "archetype": archetype,
+            "trajectory": trajectory,
+            "tournament": {
+                "tier": tournament.tier,
+                "participant_count": tournament.participant_count,
+                "date": tournament.date.isoformat(),
+            },
+        }
+
+        if meta_snapshot:
+            top_10 = dict(
+                sorted(
+                    meta_snapshot.archetype_shares.items(),
+                    key=lambda x: x[1],
+                    reverse=True,
+                )[:10]
+            )
+            context["meta"] = {
+                "top_archetypes": top_10,
+                "jp_signals": meta_snapshot.jp_signals,
+                "trends": meta_snapshot.trends,
+            }
+
+        if new_sets:
+            context["new_sets"] = [
+                {"name": s.name, "release_date": s.release_date.isoformat()}
+                for s in new_sets
+                if s.release_date
+            ]
+
+        return context
+
+    async def _generate_prediction(
+        self,
+        archetype: str,
+        context: dict,
+    ) -> dict:
+        """Use Claude to generate the prediction."""
+        system_prompt = (
+            "You are a Pokemon TCG meta analyst generating predictions "
+            "for upcoming tournaments. Analyze the archetype's trajectory, "
+            "current meta, JP signals, and new set releases.\n\n"
+            "Respond with JSON containing:\n"
+            '- "predicted_meta_share": {"low": float, "mid": float, '
+            '"high": float}\n'
+            '- "predicted_day2_rate": {"low": float, "mid": float, '
+            '"high": float}\n'
+            '- "predicted_tier": one of "S", "A", "B", "C", "Rogue"\n'
+            '- "likely_adaptations": list of {{"type": str, '
+            '"description": str, "cards": list}}\n'
+            '- "jp_signals": dict with any relevant JP meta signals\n'
+            '- "confidence": float 0.0-1.0\n'
+            '- "methodology": 2-3 sentence explanation of reasoning'
+        )
+
+        user_prompt = (
+            f"Predict {archetype}'s performance:\n\n{json.dumps(context, indent=2)}"
+        )
+
+        result = await self.claude.classify(
+            system=system_prompt,
+            user=user_prompt,
+            model=MODEL_SONNET,
+            max_tokens=1024,
+        )
+
+        return result

--- a/apps/api/tests/test_adaptation_classifier.py
+++ b/apps/api/tests/test_adaptation_classifier.py
@@ -1,0 +1,289 @@
+"""Tests for the AdaptationClassifier."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.clients.claude import ClaudeError
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.meta_snapshot import MetaSnapshot
+from src.services.adaptation_classifier import (
+    AdaptationClassifier,
+    AdaptationClassifierError,
+)
+
+_UNSET = object()
+
+
+def _make_execute_result(*, scalar_one_or_none=_UNSET, scalars_all=_UNSET):
+    """Create a mock result from session.execute()."""
+    mock_result = MagicMock()
+    if scalar_one_or_none is not _UNSET:
+        mock_result.scalar_one_or_none.return_value = scalar_one_or_none
+    if scalars_all is not _UNSET:
+        mock_result.scalars.return_value.all.return_value = scalars_all
+    return mock_result
+
+
+def _make_adaptation(**kwargs) -> MagicMock:
+    """Create a mock Adaptation."""
+    mock = MagicMock(spec=Adaptation)
+    mock.type = kwargs.get("type", "tech")
+    mock.description = kwargs.get("description", "Added Drapion V")
+    mock.cards_added = kwargs.get("cards_added", [{"name": "Drapion V", "quantity": 1}])
+    mock.cards_removed = kwargs.get("cards_removed")
+    mock.confidence = kwargs.get("confidence")
+    mock.prevalence = kwargs.get("prevalence")
+    mock.target_archetype = kwargs.get("target_archetype")
+    mock.source = kwargs.get("source", "diff")
+    mock.snapshot_id = kwargs.get("snapshot_id", uuid4())
+    return mock
+
+
+class TestClassify:
+    """Tests for adaptation classification."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def classifier(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> AdaptationClassifier:
+        return AdaptationClassifier(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_classifies_adaptation(
+        self, classifier: AdaptationClassifier, mock_claude: AsyncMock
+    ) -> None:
+        """Should update adaptation fields from Claude response."""
+        mock_claude.classify.return_value = {
+            "type": "tech",
+            "description": "Drapion V added to counter Gardevoir ex",
+            "target_archetype": "Gardevoir ex",
+            "confidence": 0.85,
+            "prevalence": 0.6,
+        }
+
+        adaptation = _make_adaptation()
+        result = await classifier.classify(adaptation)
+
+        assert result.type == "tech"
+        assert result.description == "Drapion V added to counter Gardevoir ex"
+        assert result.target_archetype == "Gardevoir ex"
+        assert result.confidence == 0.85
+        assert result.prevalence == 0.6
+        assert result.source == "claude"
+
+    @pytest.mark.asyncio
+    async def test_classifies_with_meta_context(
+        self, classifier: AdaptationClassifier, mock_claude: AsyncMock
+    ) -> None:
+        """Should pass meta context to Claude."""
+        mock_claude.classify.return_value = {
+            "type": "consistency",
+            "description": "Increased draw support",
+            "confidence": 0.7,
+            "prevalence": 0.4,
+        }
+
+        adaptation = _make_adaptation()
+        meta_ctx = {"top_archetypes": {"Charizard ex": 0.15}}
+        result = await classifier.classify(adaptation, meta_context=meta_ctx)
+
+        assert result.type == "consistency"
+        # Verify Claude was called with meta context in user prompt
+        call_args = mock_claude.classify.call_args
+        assert "Charizard ex" in call_args.kwargs["user"]
+
+    @pytest.mark.asyncio
+    async def test_raises_on_claude_error(
+        self, classifier: AdaptationClassifier, mock_claude: AsyncMock
+    ) -> None:
+        """Should raise AdaptationClassifierError on Claude failure."""
+        mock_claude.classify.side_effect = ClaudeError("API error")
+
+        adaptation = _make_adaptation()
+        with pytest.raises(AdaptationClassifierError, match="Failed to classify"):
+            await classifier.classify(adaptation)
+
+
+class TestGenerateMetaContext:
+    """Tests for meta context generation."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def classifier(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> AdaptationClassifier:
+        return AdaptationClassifier(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_generates_context_string(
+        self, classifier: AdaptationClassifier, mock_claude: AsyncMock
+    ) -> None:
+        """Should return a context string from Claude."""
+        expected = (
+            "Charizard ex adapts to the Gardevoir-heavy meta by adding "
+            "Drapion V as a tech counter."
+        )
+        mock_claude.generate.return_value = expected
+
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.archetype = "Charizard ex"
+        snapshot.meta_share = 0.12
+        snapshot.top_cut_conversion = 0.4
+        snapshot.best_placement = 2
+        snapshot.deck_count = 8
+
+        adaptations = [_make_adaptation()]
+
+        result = await classifier.generate_meta_context(snapshot, adaptations)
+        assert result == expected
+        mock_claude.generate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_includes_meta_snapshot_data(
+        self, classifier: AdaptationClassifier, mock_claude: AsyncMock
+    ) -> None:
+        """Should include meta snapshot data when provided."""
+        mock_claude.generate.return_value = "Context with meta data."
+
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.archetype = "Charizard ex"
+        snapshot.meta_share = 0.12
+        snapshot.top_cut_conversion = 0.4
+        snapshot.best_placement = 2
+        snapshot.deck_count = 8
+
+        meta_snapshot = MagicMock(spec=MetaSnapshot)
+        meta_snapshot.archetype_shares = {
+            "Charizard ex": 0.15,
+            "Gardevoir ex": 0.12,
+        }
+        meta_snapshot.jp_signals = {"rising": ["Dragapult ex"]}
+        meta_snapshot.trends = {}
+
+        result = await classifier.generate_meta_context(
+            snapshot, [_make_adaptation()], meta_snapshot
+        )
+        assert result == "Context with meta data."
+
+        call_args = mock_claude.generate.call_args
+        assert "Gardevoir ex" in call_args.kwargs["user"]
+
+    @pytest.mark.asyncio
+    async def test_raises_on_claude_error(
+        self, classifier: AdaptationClassifier, mock_claude: AsyncMock
+    ) -> None:
+        """Should raise AdaptationClassifierError on Claude failure."""
+        mock_claude.generate.side_effect = ClaudeError("API error")
+
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.archetype = "Charizard ex"
+        snapshot.meta_share = 0.12
+        snapshot.top_cut_conversion = 0.4
+        snapshot.best_placement = 2
+        snapshot.deck_count = 8
+
+        with pytest.raises(AdaptationClassifierError, match="Failed to generate"):
+            await classifier.generate_meta_context(snapshot, [_make_adaptation()])
+
+
+class TestClassifyAndContextualize:
+    """Tests for the convenience method."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def classifier(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> AdaptationClassifier:
+        return AdaptationClassifier(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_snapshot(
+        self,
+        classifier: AdaptationClassifier,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should return None when snapshot not found."""
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=None
+        )
+
+        result = await classifier.classify_and_contextualize(uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_adaptations(
+        self,
+        classifier: AdaptationClassifier,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should return None when no adaptations exist."""
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=snapshot),
+            _make_execute_result(scalars_all=[]),
+        ]
+
+        result = await classifier.classify_and_contextualize(uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_classifies_and_generates_context(
+        self,
+        classifier: AdaptationClassifier,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should classify adaptations and generate meta context."""
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.archetype = "Charizard ex"
+        snapshot.meta_share = 0.12
+        snapshot.top_cut_conversion = 0.4
+        snapshot.best_placement = 2
+        snapshot.deck_count = 8
+
+        adaptation = _make_adaptation()
+
+        mock_claude.classify.return_value = {
+            "type": "tech",
+            "description": "Counter card",
+            "confidence": 0.8,
+            "prevalence": 0.5,
+        }
+        mock_claude.generate.return_value = "Generated context."
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=snapshot),
+            _make_execute_result(scalars_all=[adaptation]),
+            _make_execute_result(scalar_one_or_none=None),  # no meta snapshot
+        ]
+
+        result = await classifier.classify_and_contextualize(uuid4())
+        assert result == "Generated context."
+        assert snapshot.meta_context == "Generated context."
+        mock_session.commit.assert_called_once()

--- a/apps/api/tests/test_evolution_article_generator.py
+++ b/apps/api/tests/test_evolution_article_generator.py
@@ -1,0 +1,300 @@
+"""Tests for the EvolutionArticleGenerator."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.clients.claude import ClaudeError
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.evolution_article import EvolutionArticle
+from src.models.lab_note import LabNote
+from src.services.evolution_article_generator import (
+    ArticleGeneratorError,
+    EvolutionArticleGenerator,
+)
+
+_UNSET = object()
+
+
+def _make_execute_result(*, scalar_one_or_none=_UNSET, scalars_all=_UNSET):
+    """Create a mock result from session.execute()."""
+    mock_result = MagicMock()
+    if scalar_one_or_none is not _UNSET:
+        mock_result.scalar_one_or_none.return_value = scalar_one_or_none
+    if scalars_all is not _UNSET:
+        mock_result.scalars.return_value.all.return_value = scalars_all
+    return mock_result
+
+
+def _make_snapshot(**kwargs) -> MagicMock:
+    """Create a mock ArchetypeEvolutionSnapshot."""
+    mock = MagicMock(spec=ArchetypeEvolutionSnapshot)
+    mock.id = kwargs.get("id", uuid4())
+    mock.archetype = kwargs.get("archetype", "Charizard ex")
+    mock.meta_share = kwargs.get("meta_share", 0.12)
+    mock.top_cut_conversion = kwargs.get("top_cut_conversion", 0.35)
+    mock.best_placement = kwargs.get("best_placement", 2)
+    mock.deck_count = kwargs.get("deck_count", 8)
+    mock.meta_context = kwargs.get("meta_context")
+    return mock
+
+
+def _make_adaptation(**kwargs) -> MagicMock:
+    """Create a mock Adaptation."""
+    mock = MagicMock(spec=Adaptation)
+    mock.type = kwargs.get("type", "tech")
+    mock.description = kwargs.get("description", "Added Drapion V")
+    mock.cards_added = kwargs.get("cards_added", [{"name": "Drapion V", "quantity": 1}])
+    mock.cards_removed = kwargs.get("cards_removed")
+    return mock
+
+
+class TestGenerateArticle:
+    """Tests for article generation."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def generator(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> EvolutionArticleGenerator:
+        return EvolutionArticleGenerator(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_generates_article(
+        self,
+        generator: EvolutionArticleGenerator,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should generate an article with title, intro, conclusion."""
+        snapshots = [_make_snapshot() for _ in range(3)]
+        adaptations = [_make_adaptation()]
+
+        mock_claude.classify.return_value = {
+            "title": "Charizard ex: Adapting to the New Meta",
+            "excerpt": "How Charizard ex evolved through recent tournaments.",
+            "introduction": "Charizard ex has undergone significant changes.",
+            "conclusion": "Looking ahead, Charizard ex remains a top contender.",
+        }
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=snapshots),  # snapshots
+            _make_execute_result(scalars_all=adaptations),  # adaptations
+            _make_execute_result(scalar_one_or_none=None),  # no prediction
+        ]
+
+        article = await generator.generate_article("Charizard ex")
+
+        assert isinstance(article, EvolutionArticle)
+        assert article.archetype_id == "Charizard ex"
+        assert article.title == "Charizard ex: Adapting to the New Meta"
+        assert article.excerpt is not None
+        assert article.introduction is not None
+        assert article.conclusion is not None
+        assert article.status == "draft"
+        assert "charizard-ex" in article.slug
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_snapshots(
+        self,
+        generator: EvolutionArticleGenerator,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should raise ArticleGeneratorError when no snapshots found."""
+        mock_session.execute.return_value = _make_execute_result(scalars_all=[])
+
+        with pytest.raises(ArticleGeneratorError, match="No snapshots"):
+            await generator.generate_article("Unknown Archetype")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_claude_error(
+        self,
+        generator: EvolutionArticleGenerator,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should raise ArticleGeneratorError on Claude failure."""
+        snapshots = [_make_snapshot()]
+
+        mock_claude.classify.side_effect = ClaudeError("API error")
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=snapshots),
+            _make_execute_result(scalars_all=[]),  # no adaptations
+            _make_execute_result(scalar_one_or_none=None),  # no prediction
+        ]
+
+        with pytest.raises(ArticleGeneratorError, match="Failed to generate"):
+            await generator.generate_article("Charizard ex")
+
+    @pytest.mark.asyncio
+    async def test_includes_prediction_context(
+        self,
+        generator: EvolutionArticleGenerator,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should include prediction data when available."""
+        snapshots = [_make_snapshot()]
+        prediction = MagicMock(spec=ArchetypePrediction)
+        prediction.predicted_tier = "S"
+        prediction.predicted_meta_share = {"mid": 0.15}
+        prediction.methodology = "Strong trajectory."
+        prediction.created_at = datetime.now(UTC)
+
+        mock_claude.classify.return_value = {
+            "title": "Charizard ex Evolution",
+            "introduction": "Intro text.",
+            "conclusion": "Conclusion text.",
+        }
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=snapshots),  # snapshots
+            _make_execute_result(scalars_all=[]),  # no adaptations
+            _make_execute_result(scalar_one_or_none=prediction),  # prediction
+        ]
+
+        article = await generator.generate_article("Charizard ex")
+        assert article.title == "Charizard ex Evolution"
+
+        call_args = mock_claude.classify.call_args
+        assert "Strong trajectory" in call_args.kwargs["user"]
+
+
+class TestLinkSnapshots:
+    """Tests for snapshot linking."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def generator(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> EvolutionArticleGenerator:
+        return EvolutionArticleGenerator(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_creates_junction_records(
+        self, generator: EvolutionArticleGenerator
+    ) -> None:
+        """Should create EvolutionArticleSnapshot records with positions."""
+        article = MagicMock(spec=EvolutionArticle)
+        article.id = uuid4()
+
+        ids = [uuid4(), uuid4(), uuid4()]
+        links = await generator.link_snapshots(article, ids)
+
+        assert len(links) == 3
+        assert links[0].article_id == article.id
+        assert links[0].snapshot_id == ids[0]
+        assert links[0].position == 0
+        assert links[1].position == 1
+        assert links[2].position == 2
+
+
+class TestPublishArticle:
+    """Tests for article publishing."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def generator(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> EvolutionArticleGenerator:
+        return EvolutionArticleGenerator(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_publishes_and_creates_lab_note(
+        self,
+        generator: EvolutionArticleGenerator,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should set published status and create a LabNote."""
+        article = MagicMock(spec=EvolutionArticle)
+        article.id = uuid4()
+        article.archetype_id = "Charizard ex"
+        article.slug = "charizard-ex-evolution-20260203"
+        article.title = "Charizard ex Evolution"
+        article.excerpt = "How Charizard adapted."
+        article.introduction = "Intro."
+        article.conclusion = "Conclusion."
+
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=article
+        )
+
+        lab_note = await generator.publish_article(article.id)
+
+        assert article.status == "published"
+        assert article.published_at is not None
+        assert lab_note is not None
+        assert isinstance(lab_note, LabNote)
+        assert lab_note.note_type == "archetype_evolution"
+        assert lab_note.title == "Charizard ex Evolution"
+        assert lab_note.is_published is True
+        assert "evolution" in lab_note.tags
+        mock_session.add.assert_called_once_with(lab_note)
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_article_not_found(
+        self,
+        generator: EvolutionArticleGenerator,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should return None when article doesn't exist."""
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=None
+        )
+
+        result = await generator.publish_article(uuid4())
+        assert result is None
+
+
+class TestGenerateSlug:
+    """Tests for slug generation."""
+
+    @pytest.fixture
+    def generator(self) -> EvolutionArticleGenerator:
+        return EvolutionArticleGenerator(AsyncMock(), AsyncMock())
+
+    def test_generates_valid_slug(self, generator: EvolutionArticleGenerator) -> None:
+        """Should produce a URL-safe slug."""
+        slug = generator._generate_slug("Charizard ex")
+        assert "charizard-ex" in slug
+        assert "evolution" in slug
+        # Should not contain special characters
+        assert " " not in slug
+        assert slug == slug.lower()
+
+    def test_handles_special_characters(
+        self, generator: EvolutionArticleGenerator
+    ) -> None:
+        """Should strip special characters from slug."""
+        slug = generator._generate_slug("Lugia VSTAR/Archeops")
+        assert (
+            "lugia-vstararcheops" in slug
+            or "lugia-vstar" in slug.split("-evolution")[0]
+        )

--- a/apps/api/tests/test_prediction_engine.py
+++ b/apps/api/tests/test_prediction_engine.py
@@ -1,0 +1,269 @@
+"""Tests for the PredictionEngine."""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.clients.claude import ClaudeError
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.meta_snapshot import MetaSnapshot
+from src.models.tournament import Tournament
+from src.services.prediction_engine import (
+    PredictionEngine,
+    PredictionEngineError,
+)
+
+_UNSET = object()
+
+
+def _make_execute_result(*, scalar_one_or_none=_UNSET, scalars_all=_UNSET):
+    """Create a mock result from session.execute()."""
+    mock_result = MagicMock()
+    if scalar_one_or_none is not _UNSET:
+        mock_result.scalar_one_or_none.return_value = scalar_one_or_none
+    if scalars_all is not _UNSET:
+        mock_result.scalars.return_value.all.return_value = scalars_all
+    return mock_result
+
+
+def _make_tournament(**kwargs) -> MagicMock:
+    """Create a mock Tournament."""
+    mock = MagicMock(spec=Tournament)
+    mock.id = kwargs.get("id", uuid4())
+    mock.tier = kwargs.get("tier", "major")
+    mock.participant_count = kwargs.get("participant_count", 256)
+    mock.date = kwargs.get("date", date(2026, 3, 15))
+    return mock
+
+
+def _make_snapshot(**kwargs) -> MagicMock:
+    """Create a mock ArchetypeEvolutionSnapshot."""
+    mock = MagicMock(spec=ArchetypeEvolutionSnapshot)
+    mock.id = kwargs.get("id", uuid4())
+    mock.archetype = kwargs.get("archetype", "Charizard ex")
+    mock.meta_share = kwargs.get("meta_share", 0.12)
+    mock.top_cut_conversion = kwargs.get("top_cut_conversion", 0.35)
+    mock.best_placement = kwargs.get("best_placement", 2)
+    mock.deck_count = kwargs.get("deck_count", 8)
+    mock.tournament_id = kwargs.get("tournament_id", uuid4())
+    return mock
+
+
+class TestPredict:
+    """Tests for prediction generation."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def engine(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> PredictionEngine:
+        return PredictionEngine(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_generates_prediction(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should generate a prediction with all fields populated."""
+        tournament = _make_tournament()
+        snapshots = [_make_snapshot() for _ in range(3)]
+
+        mock_claude.classify.return_value = {
+            "predicted_meta_share": {"low": 0.08, "mid": 0.12, "high": 0.16},
+            "predicted_day2_rate": {"low": 0.3, "mid": 0.4, "high": 0.5},
+            "predicted_tier": "A",
+            "likely_adaptations": [{"type": "tech", "description": "Add Drapion V"}],
+            "jp_signals": {"trending": True},
+            "confidence": 0.75,
+            "methodology": "Based on rising trajectory and JP signals.",
+        }
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=snapshots),  # recent snapshots
+            _make_execute_result(scalar_one_or_none=tournament),  # tournament
+            _make_execute_result(scalar_one_or_none=None),  # meta snapshot
+            _make_execute_result(scalars_all=[]),  # upcoming sets
+        ]
+
+        prediction = await engine.predict("Charizard ex", tournament.id)
+
+        assert isinstance(prediction, ArchetypePrediction)
+        assert prediction.archetype_id == "Charizard ex"
+        assert prediction.target_tournament_id == tournament.id
+        assert prediction.predicted_tier == "A"
+        assert prediction.predicted_meta_share == {
+            "low": 0.08,
+            "mid": 0.12,
+            "high": 0.16,
+        }
+        assert prediction.confidence == 0.75
+        assert prediction.methodology is not None
+
+    @pytest.mark.asyncio
+    async def test_raises_when_tournament_not_found(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should raise PredictionEngineError when tournament not found."""
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=[]),  # recent snapshots
+            _make_execute_result(scalar_one_or_none=None),  # no tournament
+        ]
+
+        with pytest.raises(PredictionEngineError, match="not found"):
+            await engine.predict("Charizard ex", uuid4())
+
+    @pytest.mark.asyncio
+    async def test_raises_on_claude_error(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should raise PredictionEngineError on Claude failure."""
+        tournament = _make_tournament()
+
+        mock_claude.classify.side_effect = ClaudeError("API error")
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=[]),  # no snapshots
+            _make_execute_result(scalar_one_or_none=tournament),  # tournament
+            _make_execute_result(scalar_one_or_none=None),  # meta snapshot
+            _make_execute_result(scalars_all=[]),  # upcoming sets
+        ]
+
+        with pytest.raises(PredictionEngineError, match="Failed to generate"):
+            await engine.predict("Charizard ex", tournament.id)
+
+    @pytest.mark.asyncio
+    async def test_includes_meta_snapshot_context(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+        mock_claude: AsyncMock,
+    ) -> None:
+        """Should include meta snapshot data in prediction context."""
+        tournament = _make_tournament()
+        meta_snapshot = MagicMock(spec=MetaSnapshot)
+        meta_snapshot.archetype_shares = {
+            "Charizard ex": 0.15,
+            "Gardevoir ex": 0.12,
+        }
+        meta_snapshot.jp_signals = {"rising": ["Dragapult ex"]}
+        meta_snapshot.trends = {"Charizard ex": {"direction": "up"}}
+
+        mock_claude.classify.return_value = {
+            "predicted_meta_share": {"low": 0.10, "mid": 0.15, "high": 0.20},
+            "predicted_tier": "S",
+            "confidence": 0.8,
+            "methodology": "Strong trajectory with JP support.",
+        }
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=[]),  # no snapshots
+            _make_execute_result(scalar_one_or_none=tournament),  # tournament
+            _make_execute_result(scalar_one_or_none=meta_snapshot),  # meta
+            _make_execute_result(scalars_all=[]),  # no new sets
+        ]
+
+        prediction = await engine.predict("Charizard ex", tournament.id)
+        assert prediction.predicted_tier == "S"
+
+        call_args = mock_claude.classify.call_args
+        assert "Gardevoir ex" in call_args.kwargs["user"]
+
+
+class TestScorePrediction:
+    """Tests for post-event scoring."""
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_claude(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def engine(
+        self, mock_session: AsyncMock, mock_claude: AsyncMock
+    ) -> PredictionEngine:
+        return PredictionEngine(mock_session, mock_claude)
+
+    @pytest.mark.asyncio
+    async def test_scores_prediction_accurately(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should compute accuracy score from actual vs predicted."""
+        prediction = MagicMock(spec=ArchetypePrediction)
+        prediction.archetype_id = "Charizard ex"
+        prediction.target_tournament_id = uuid4()
+        prediction.predicted_meta_share = {
+            "low": 0.08,
+            "mid": 0.12,
+            "high": 0.16,
+        }
+
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.meta_share = 0.11  # Close to mid=0.12
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=prediction),
+            _make_execute_result(scalar_one_or_none=snapshot),
+        ]
+
+        await engine.score_prediction(uuid4())
+
+        assert prediction.actual_meta_share == 0.11
+        # Error = |0.11 - 0.12| / 0.12 = 0.0833...
+        # Accuracy = 1 - 0.0833 = 0.9167
+        assert prediction.accuracy_score == round(1.0 - abs(0.11 - 0.12) / 0.12, 4)
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_prediction_not_found(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should raise PredictionEngineError."""
+        mock_session.execute.return_value = _make_execute_result(
+            scalar_one_or_none=None
+        )
+
+        with pytest.raises(PredictionEngineError, match="not found"):
+            await engine.score_prediction(uuid4())
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_snapshot(
+        self,
+        engine: PredictionEngine,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Should return without scoring when no snapshot found."""
+        prediction = MagicMock(spec=ArchetypePrediction)
+        prediction.archetype_id = "Charizard ex"
+        prediction.target_tournament_id = uuid4()
+
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalar_one_or_none=prediction),
+            _make_execute_result(scalar_one_or_none=None),  # no snapshot
+        ]
+
+        await engine.score_prediction(uuid4())
+        mock_session.commit.assert_not_called()

--- a/apps/api/tests/test_tcgdex_client.py
+++ b/apps/api/tests/test_tcgdex_client.py
@@ -335,6 +335,28 @@ class TestTCGdexClient:
             await client._get("/en/sets/invalid")
 
     @pytest.mark.asyncio
+    async def test_fetch_card_encodes_special_characters(self, client: TCGdexClient):
+        """Test that card IDs with special characters are URL-encoded."""
+        mock_response = {
+            "id": "exu-?",
+            "localId": "?",
+            "name": "Promo Card",
+            "category": "Pokemon",
+            "set": {"id": "exu"},
+            "legal": {},
+        }
+
+        async def mock_get(endpoint: str):
+            # Verify the endpoint has the encoded card_id
+            assert endpoint == "/en/cards/exu-%3F"
+            return mock_response
+
+        with patch.object(client, "_get", side_effect=mock_get):
+            card = await client.fetch_card("exu-?")
+            assert card.id == "exu-?"
+            assert card.name == "Promo Card"
+
+    @pytest.mark.asyncio
     async def test_context_manager(self):
         """Test async context manager."""
         async with TCGdexClient(base_url="https://api.tcgdex.net/v2") as client:


### PR DESCRIPTION
## Summary
- **#267**: Fix URL encoding for TCGdex card IDs with special characters (e.g., `?` in `exu` set)
- **#276**: Add `AdaptationClassifier` service — classifies adaptations using Claude Haiku and generates meta context explanations using Claude Sonnet
- **#277**: Add `PredictionEngine` service — forecasts archetype performance at upcoming tournaments using historical snapshots, JP signals, and new set releases
- **#279**: Add `EvolutionArticleGenerator` service — generates narrative evolution articles with introduction/conclusion, links snapshots via junction table, and publishes with summary Lab Notes

## Test plan
- [x] 40 new/modified tests passing (9 classifier, 7 prediction, 10 article generator, 1 URL encoding + 13 existing tcgdex tests)
- [x] Full suite: 718 passed (1 pre-existing failure unrelated to this PR)
- [x] Ruff lint and format clean
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)