### PR TITLE
feat: evolution intelligence pipeline and API endpoints (#278, #280)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -16,6 +16,7 @@ from src.config import get_settings
 from src.routers import (
     cards_router,
     decks_router,
+    evolution_router,
     format_router,
     health_router,
     japan_router,
@@ -106,6 +107,7 @@ app.add_middleware(
 # Include routers
 app.include_router(cards_router)
 app.include_router(decks_router)
+app.include_router(evolution_router)
 app.include_router(format_router)
 app.include_router(health_router)
 app.include_router(japan_router)

--- a/apps/api/src/pipelines/compute_evolution.py
+++ b/apps/api/src/pipelines/compute_evolution.py
@@ -1,0 +1,295 @@
+"""Evolution intelligence pipeline.
+
+Daily pipeline that runs AI-powered evolution analysis:
+classifies adaptations, generates meta context, updates predictions,
+and generates evolution articles.
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.clients.claude import ClaudeClient
+from src.db.database import async_session_factory
+from src.models.adaptation import Adaptation
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.tournament import Tournament
+from src.services.adaptation_classifier import AdaptationClassifier
+from src.services.evolution_article_generator import EvolutionArticleGenerator
+from src.services.prediction_engine import PredictionEngine
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ComputeEvolutionResult:
+    """Result of compute_evolution pipeline."""
+
+    adaptations_classified: int = 0
+    contexts_generated: int = 0
+    predictions_generated: int = 0
+    articles_generated: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return len(self.errors) == 0
+
+
+async def compute_evolution_intelligence(
+    dry_run: bool = False,
+) -> ComputeEvolutionResult:
+    """Run the full evolution intelligence pipeline.
+
+    Steps:
+    1. Find unclassified adaptations and classify with Claude
+    2. Generate meta_context for snapshots missing it
+    3. Generate/update predictions for upcoming major events
+    4. Generate/update evolution articles for active archetypes
+
+    Args:
+        dry_run: If true, skip persistence steps.
+
+    Returns:
+        ComputeEvolutionResult with pipeline statistics.
+    """
+    result = ComputeEvolutionResult()
+
+    try:
+        async with ClaudeClient() as claude, async_session_factory() as session:
+            classifier = AdaptationClassifier(session, claude)
+            prediction_engine = PredictionEngine(session, claude)
+            article_generator = EvolutionArticleGenerator(session, claude)
+
+            # Step 1: Classify unclassified adaptations
+            await _classify_adaptations(session, classifier, result, dry_run)
+
+            # Step 2: Generate meta context for snapshots missing it
+            await _generate_meta_contexts(session, classifier, result, dry_run)
+
+            # Step 3: Generate predictions for upcoming tournaments
+            await _generate_predictions(session, prediction_engine, result, dry_run)
+
+            # Step 4: Generate evolution articles
+            await _generate_articles(session, article_generator, result, dry_run)
+
+    except SQLAlchemyError as e:
+        logger.error("Database error in evolution pipeline: %s", e)
+        result.errors.append(f"Database error: {e}")
+    except Exception as e:
+        logger.error("Unexpected error in evolution pipeline: %s", e)
+        result.errors.append(f"Unexpected error: {e}")
+
+    logger.info(
+        "Evolution pipeline complete: classified=%d, contexts=%d, "
+        "predictions=%d, articles=%d, errors=%d",
+        result.adaptations_classified,
+        result.contexts_generated,
+        result.predictions_generated,
+        result.articles_generated,
+        len(result.errors),
+    )
+
+    return result
+
+
+async def _classify_adaptations(
+    session,
+    classifier: AdaptationClassifier,
+    result: ComputeEvolutionResult,
+    dry_run: bool,
+) -> None:
+    """Find and classify unclassified adaptations."""
+    query = select(Adaptation).where(
+        Adaptation.source != "claude",
+    )
+    db_result = await session.execute(query)
+    adaptations = list(db_result.scalars().all())
+
+    logger.info("Found %d unclassified adaptations", len(adaptations))
+
+    for adaptation in adaptations:
+        try:
+            if not dry_run:
+                await classifier.classify(adaptation)
+            result.adaptations_classified += 1
+        except Exception as e:
+            logger.warning(
+                "Failed to classify adaptation %s: %s",
+                adaptation.id,
+                e,
+            )
+            result.errors.append(
+                f"Classification failed for adaptation {adaptation.id}: {e}"
+            )
+
+    if not dry_run and adaptations:
+        await session.commit()
+
+
+async def _generate_meta_contexts(
+    session,
+    classifier: AdaptationClassifier,
+    result: ComputeEvolutionResult,
+    dry_run: bool,
+) -> None:
+    """Generate meta context for snapshots that don't have one."""
+    query = select(ArchetypeEvolutionSnapshot).where(
+        ArchetypeEvolutionSnapshot.meta_context.is_(None),
+    )
+    db_result = await session.execute(query)
+    snapshots = list(db_result.scalars().all())
+
+    logger.info("Found %d snapshots missing meta context", len(snapshots))
+
+    for snapshot in snapshots:
+        try:
+            if not dry_run:
+                context = await classifier.classify_and_contextualize(snapshot.id)
+                if context:
+                    result.contexts_generated += 1
+            else:
+                result.contexts_generated += 1
+        except Exception as e:
+            logger.warning(
+                "Failed to generate context for snapshot %s: %s",
+                snapshot.id,
+                e,
+            )
+            result.errors.append(
+                f"Context generation failed for snapshot {snapshot.id}: {e}"
+            )
+
+
+async def _generate_predictions(
+    session,
+    engine: PredictionEngine,
+    result: ComputeEvolutionResult,
+    dry_run: bool,
+) -> None:
+    """Generate predictions for upcoming major tournaments."""
+    # Find upcoming tournaments without predictions
+    from datetime import date as date_type
+
+    today = date_type.today()
+    query = select(Tournament).where(
+        Tournament.date > today,
+        Tournament.tier.in_(["major", "premier"]),
+    )
+    db_result = await session.execute(query)
+    tournaments = list(db_result.scalars().all())
+
+    if not tournaments:
+        logger.info("No upcoming major tournaments for predictions")
+        return
+
+    # Get active archetypes (those with recent snapshots)
+    archetype_query = (
+        select(ArchetypeEvolutionSnapshot.archetype)
+        .distinct()
+        .order_by(ArchetypeEvolutionSnapshot.archetype)
+    )
+    arch_result = await session.execute(archetype_query)
+    archetypes = [row[0] for row in arch_result.all()]
+
+    logger.info(
+        "Generating predictions for %d tournaments x %d archetypes",
+        len(tournaments),
+        len(archetypes),
+    )
+
+    for tournament in tournaments:
+        for archetype in archetypes:
+            # Check if prediction already exists
+            existing = await session.execute(
+                select(ArchetypePrediction).where(
+                    ArchetypePrediction.archetype_id == archetype,
+                    ArchetypePrediction.target_tournament_id == tournament.id,
+                )
+            )
+            if existing.scalar_one_or_none():
+                continue
+
+            try:
+                if not dry_run:
+                    prediction = await engine.predict(archetype, tournament.id)
+                    session.add(prediction)
+                result.predictions_generated += 1
+            except Exception as e:
+                logger.warning(
+                    "Failed to predict %s at tournament %s: %s",
+                    archetype,
+                    tournament.id,
+                    e,
+                )
+                result.errors.append(
+                    f"Prediction failed for {archetype} at {tournament.id}: {e}"
+                )
+
+    if not dry_run:
+        await session.commit()
+
+
+async def _generate_articles(
+    session,
+    generator: EvolutionArticleGenerator,
+    result: ComputeEvolutionResult,
+    dry_run: bool,
+) -> None:
+    """Generate evolution articles for archetypes with sufficient data."""
+    # Get archetypes with 3+ snapshots
+    from sqlalchemy import func
+
+    archetype_query = (
+        select(
+            ArchetypeEvolutionSnapshot.archetype,
+            func.count(ArchetypeEvolutionSnapshot.id).label("count"),
+        )
+        .group_by(ArchetypeEvolutionSnapshot.archetype)
+        .having(func.count(ArchetypeEvolutionSnapshot.id) >= 3)
+    )
+    arch_result = await session.execute(archetype_query)
+    archetypes = [row[0] for row in arch_result.all()]
+
+    logger.info(
+        "Found %d archetypes eligible for article generation",
+        len(archetypes),
+    )
+
+    for archetype in archetypes:
+        try:
+            if not dry_run:
+                article = await generator.generate_article(archetype)
+                session.add(article)
+
+                # Link snapshots
+                snapshot_query = (
+                    select(ArchetypeEvolutionSnapshot.id)
+                    .join(
+                        Tournament,
+                        ArchetypeEvolutionSnapshot.tournament_id == Tournament.id,
+                    )
+                    .where(ArchetypeEvolutionSnapshot.archetype == archetype)
+                    .order_by(Tournament.date.desc())
+                    .limit(6)
+                )
+                snap_result = await session.execute(snapshot_query)
+                snapshot_ids = [row[0] for row in snap_result.all()]
+                links = await generator.link_snapshots(article, snapshot_ids)
+                for link in links:
+                    session.add(link)
+
+            result.articles_generated += 1
+        except Exception as e:
+            logger.warning(
+                "Failed to generate article for %s: %s",
+                archetype,
+                e,
+            )
+            result.errors.append(f"Article generation failed for {archetype}: {e}")
+
+    if not dry_run:
+        await session.commit()

--- a/apps/api/src/routers/__init__.py
+++ b/apps/api/src/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from src.routers.cards import router as cards_router
 from src.routers.decks import router as decks_router
+from src.routers.evolution import router as evolution_router
 from src.routers.format import router as format_router
 from src.routers.health import router as health_router
 from src.routers.japan import router as japan_router
@@ -16,6 +17,7 @@ from src.routers.waitlist import router as waitlist_router
 __all__ = [
     "cards_router",
     "decks_router",
+    "evolution_router",
     "format_router",
     "health_router",
     "japan_router",

--- a/apps/api/src/routers/evolution.py
+++ b/apps/api/src/routers/evolution.py
@@ -1,0 +1,380 @@
+"""Evolution API endpoints.
+
+Provides endpoints for evolution timelines, predictions,
+articles, and accuracy tracking.
+"""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.db.database import get_db
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.evolution_article import EvolutionArticle
+from src.models.evolution_article_snapshot import EvolutionArticleSnapshot
+from src.models.tournament import Tournament
+from src.schemas.evolution import (
+    AdaptationResponse,
+    EvolutionArticleListItem,
+    EvolutionArticleResponse,
+    EvolutionSnapshotResponse,
+    EvolutionTimelineResponse,
+    PredictionAccuracyResponse,
+    PredictionResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["evolution"])
+
+
+def _snapshot_to_response(
+    snapshot: ArchetypeEvolutionSnapshot,
+) -> EvolutionSnapshotResponse:
+    """Convert a snapshot model to response schema."""
+    adaptations = [
+        AdaptationResponse(
+            id=a.id,
+            type=a.type,
+            description=a.description,
+            cards_added=a.cards_added,
+            cards_removed=a.cards_removed,
+            target_archetype=a.target_archetype,
+            confidence=a.confidence,
+            source=a.source,
+        )
+        for a in (snapshot.adaptations or [])
+    ]
+
+    return EvolutionSnapshotResponse(
+        id=snapshot.id,
+        archetype=snapshot.archetype,
+        tournament_id=snapshot.tournament_id,
+        meta_share=snapshot.meta_share,
+        top_cut_conversion=snapshot.top_cut_conversion,
+        best_placement=snapshot.best_placement,
+        deck_count=snapshot.deck_count,
+        consensus_list=snapshot.consensus_list,
+        meta_context=snapshot.meta_context,
+        adaptations=adaptations,
+        created_at=snapshot.created_at,
+    )
+
+
+@router.get("/archetypes/{archetype_id}/evolution")
+async def get_archetype_evolution(
+    archetype_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[
+        int,
+        Query(ge=1, le=50, description="Maximum number of snapshots"),
+    ] = 10,
+) -> EvolutionTimelineResponse:
+    """Get the evolution timeline for an archetype.
+
+    Returns snapshots ordered by tournament date (most recent first),
+    with adaptations included for each snapshot.
+    """
+    query = (
+        select(ArchetypeEvolutionSnapshot)
+        .options(selectinload(ArchetypeEvolutionSnapshot.adaptations))
+        .join(
+            Tournament,
+            ArchetypeEvolutionSnapshot.tournament_id == Tournament.id,
+        )
+        .where(ArchetypeEvolutionSnapshot.archetype == archetype_id)
+        .order_by(Tournament.date.desc())
+        .limit(limit)
+    )
+
+    try:
+        result = await db.execute(query)
+        snapshots = list(result.scalars().all())
+    except SQLAlchemyError:
+        logger.error(
+            "Database error fetching evolution timeline: archetype=%s",
+            archetype_id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to retrieve evolution timeline.",
+        ) from None
+
+    if not snapshots:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No evolution data found for archetype '{archetype_id}'",
+        )
+
+    return EvolutionTimelineResponse(
+        archetype=archetype_id,
+        snapshots=[_snapshot_to_response(s) for s in snapshots],
+    )
+
+
+@router.get("/archetypes/{archetype_id}/prediction")
+async def get_archetype_prediction(
+    archetype_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> PredictionResponse:
+    """Get the current prediction for an archetype.
+
+    Returns the most recent prediction for any upcoming tournament.
+    """
+    query = (
+        select(ArchetypePrediction)
+        .where(ArchetypePrediction.archetype_id == archetype_id)
+        .order_by(ArchetypePrediction.created_at.desc())
+        .limit(1)
+    )
+
+    try:
+        result = await db.execute(query)
+        prediction = result.scalar_one_or_none()
+    except SQLAlchemyError:
+        logger.error(
+            "Database error fetching prediction: archetype=%s",
+            archetype_id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to retrieve prediction.",
+        ) from None
+
+    if not prediction:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No prediction found for archetype '{archetype_id}'",
+        )
+
+    return PredictionResponse(
+        id=prediction.id,
+        archetype_id=prediction.archetype_id,
+        target_tournament_id=prediction.target_tournament_id,
+        predicted_meta_share=prediction.predicted_meta_share,
+        predicted_day2_rate=prediction.predicted_day2_rate,
+        predicted_tier=prediction.predicted_tier,
+        likely_adaptations=prediction.likely_adaptations,
+        confidence=prediction.confidence,
+        methodology=prediction.methodology,
+        actual_meta_share=prediction.actual_meta_share,
+        accuracy_score=prediction.accuracy_score,
+        created_at=prediction.created_at,
+    )
+
+
+@router.get("/evolution")
+async def list_evolution_articles(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[
+        int,
+        Query(ge=1, le=50, description="Maximum number of articles"),
+    ] = 20,
+    offset: Annotated[
+        int,
+        Query(ge=0, description="Number of articles to skip"),
+    ] = 0,
+) -> list[EvolutionArticleListItem]:
+    """List published evolution articles.
+
+    Returns articles ordered by publication date (most recent first).
+    """
+    query = (
+        select(EvolutionArticle)
+        .where(EvolutionArticle.status == "published")
+        .order_by(EvolutionArticle.published_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    try:
+        result = await db.execute(query)
+        articles = list(result.scalars().all())
+    except SQLAlchemyError:
+        logger.error(
+            "Database error fetching evolution articles",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to retrieve articles.",
+        ) from None
+
+    return [
+        EvolutionArticleListItem(
+            id=a.id,
+            archetype_id=a.archetype_id,
+            slug=a.slug,
+            title=a.title,
+            excerpt=a.excerpt,
+            status=a.status,
+            is_premium=a.is_premium,
+            published_at=a.published_at,
+        )
+        for a in articles
+    ]
+
+
+@router.get("/evolution/accuracy")
+async def get_prediction_accuracy(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[
+        int,
+        Query(ge=1, le=100, description="Maximum scored predictions to include"),
+    ] = 20,
+) -> PredictionAccuracyResponse:
+    """Get prediction accuracy tracking summary.
+
+    Returns overall accuracy statistics and recent scored predictions.
+    """
+    try:
+        # Get total and scored counts
+        total_result = await db.execute(select(func.count(ArchetypePrediction.id)))
+        total = total_result.scalar() or 0
+
+        scored_result = await db.execute(
+            select(func.count(ArchetypePrediction.id)).where(
+                ArchetypePrediction.accuracy_score.is_not(None)
+            )
+        )
+        scored = scored_result.scalar() or 0
+
+        # Get average accuracy
+        avg_result = await db.execute(
+            select(func.avg(ArchetypePrediction.accuracy_score)).where(
+                ArchetypePrediction.accuracy_score.is_not(None)
+            )
+        )
+        avg_accuracy = avg_result.scalar()
+
+        # Get recent scored predictions
+        predictions_result = await db.execute(
+            select(ArchetypePrediction)
+            .where(ArchetypePrediction.accuracy_score.is_not(None))
+            .order_by(ArchetypePrediction.created_at.desc())
+            .limit(limit)
+        )
+        predictions = list(predictions_result.scalars().all())
+
+    except SQLAlchemyError:
+        logger.error(
+            "Database error fetching prediction accuracy",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to retrieve prediction accuracy.",
+        ) from None
+
+    return PredictionAccuracyResponse(
+        total_predictions=total,
+        scored_predictions=scored,
+        average_accuracy=round(float(avg_accuracy), 4) if avg_accuracy else None,
+        predictions=[
+            PredictionResponse(
+                id=p.id,
+                archetype_id=p.archetype_id,
+                target_tournament_id=p.target_tournament_id,
+                predicted_meta_share=p.predicted_meta_share,
+                predicted_day2_rate=p.predicted_day2_rate,
+                predicted_tier=p.predicted_tier,
+                likely_adaptations=p.likely_adaptations,
+                confidence=p.confidence,
+                methodology=p.methodology,
+                actual_meta_share=p.actual_meta_share,
+                accuracy_score=p.accuracy_score,
+                created_at=p.created_at,
+            )
+            for p in predictions
+        ],
+    )
+
+
+@router.get("/evolution/{slug}")
+async def get_evolution_article(
+    slug: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EvolutionArticleResponse:
+    """Get a single evolution article by slug.
+
+    Returns the full article with linked snapshots.
+    """
+    query = (
+        select(EvolutionArticle)
+        .options(
+            selectinload(EvolutionArticle.article_snapshots).selectinload(
+                EvolutionArticleSnapshot.snapshot
+            )
+        )
+        .where(EvolutionArticle.slug == slug)
+    )
+
+    try:
+        result = await db.execute(query)
+        article = result.scalar_one_or_none()
+    except SQLAlchemyError:
+        logger.error(
+            "Database error fetching evolution article: slug=%s",
+            slug,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to retrieve article.",
+        ) from None
+
+    if not article:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article '{slug}' not found",
+        )
+
+    # Increment view count
+    article.view_count = (article.view_count or 0) + 1
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+
+    # Build snapshot responses from junction table
+    snapshot_responses = []
+    for link in sorted(article.article_snapshots, key=lambda x: x.position):
+        if link.snapshot:
+            snapshot_responses.append(
+                EvolutionSnapshotResponse(
+                    id=link.snapshot.id,
+                    archetype=link.snapshot.archetype,
+                    tournament_id=link.snapshot.tournament_id,
+                    meta_share=link.snapshot.meta_share,
+                    top_cut_conversion=link.snapshot.top_cut_conversion,
+                    best_placement=link.snapshot.best_placement,
+                    deck_count=link.snapshot.deck_count,
+                    consensus_list=link.snapshot.consensus_list,
+                    meta_context=link.snapshot.meta_context,
+                    created_at=link.snapshot.created_at,
+                )
+            )
+
+    return EvolutionArticleResponse(
+        id=article.id,
+        archetype_id=article.archetype_id,
+        slug=article.slug,
+        title=article.title,
+        excerpt=article.excerpt,
+        introduction=article.introduction,
+        conclusion=article.conclusion,
+        status=article.status,
+        is_premium=article.is_premium,
+        published_at=article.published_at,
+        view_count=article.view_count,
+        share_count=article.share_count,
+        snapshots=snapshot_responses,
+    )

--- a/apps/api/src/schemas/__init__.py
+++ b/apps/api/src/schemas/__init__.py
@@ -20,6 +20,15 @@ from src.schemas.deck import (
     UnmatchedCard,
     UserSummary,
 )
+from src.schemas.evolution import (
+    AdaptationResponse,
+    EvolutionArticleListItem,
+    EvolutionArticleResponse,
+    EvolutionSnapshotResponse,
+    EvolutionTimelineResponse,
+    PredictionAccuracyResponse,
+    PredictionResponse,
+)
 from src.schemas.format import (
     FormatConfigResponse,
     RotatingCard,
@@ -52,6 +61,8 @@ from src.schemas.meta import (
 )
 from src.schemas.pagination import PaginatedResponse
 from src.schemas.pipeline import (
+    ComputeEvolutionRequest,
+    ComputeEvolutionResult,
     ComputeMetaRequest,
     ComputeMetaResult,
     PipelineRequest,
@@ -86,8 +97,15 @@ __all__ = [
     "CardSummaryResponse",
     "CardUsageResponse",
     "CardUsageSummary",
+    "AdaptationResponse",
+    "ComputeEvolutionRequest",
+    "ComputeEvolutionResult",
     "ComputeMetaRequest",
     "ComputeMetaResult",
+    "EvolutionArticleListItem",
+    "EvolutionArticleResponse",
+    "EvolutionSnapshotResponse",
+    "EvolutionTimelineResponse",
     "DeckCreate",
     "DeckImportRequest",
     "DeckImportResponse",
@@ -111,6 +129,8 @@ __all__ = [
     "MetaSnapshotResponse",
     "PaginatedResponse",
     "PipelineRequest",
+    "PredictionAccuracyResponse",
+    "PredictionResponse",
     "RotatingCard",
     "RotationDetails",
     "RotationImpactListResponse",

--- a/apps/api/src/schemas/evolution.py
+++ b/apps/api/src/schemas/evolution.py
@@ -1,0 +1,168 @@
+"""Evolution API Pydantic schemas."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AdaptationResponse(BaseModel):
+    """Single adaptation in a snapshot."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(description="Adaptation ID")
+    type: str = Field(
+        description="Adaptation type (tech, consistency, engine, removal)"
+    )
+    description: str | None = Field(
+        default=None, description="Human-readable description"
+    )
+    cards_added: list[dict] | None = Field(
+        default=None, description="Cards added in this adaptation"
+    )
+    cards_removed: list[dict] | None = Field(
+        default=None, description="Cards removed in this adaptation"
+    )
+    target_archetype: str | None = Field(
+        default=None, description="Target archetype if tech choice"
+    )
+    confidence: float | None = Field(
+        default=None, description="Classification confidence"
+    )
+    source: str | None = Field(
+        default=None,
+        description="Classification source (diff, claude)",
+    )
+
+
+class EvolutionSnapshotResponse(BaseModel):
+    """Evolution snapshot for a single tournament."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(description="Snapshot ID")
+    archetype: str = Field(description="Archetype name")
+    tournament_id: UUID = Field(description="Tournament ID")
+    meta_share: float | None = Field(
+        default=None, description="Meta share at tournament"
+    )
+    top_cut_conversion: float | None = Field(
+        default=None, description="Top cut conversion rate"
+    )
+    best_placement: int | None = Field(
+        default=None, description="Best placement achieved"
+    )
+    deck_count: int = Field(description="Number of decks in sample")
+    consensus_list: list[dict] | None = Field(
+        default=None, description="Consensus decklist"
+    )
+    meta_context: str | None = Field(
+        default=None, description="AI-generated meta context"
+    )
+    adaptations: list[AdaptationResponse] = Field(
+        default_factory=list, description="Adaptations detected"
+    )
+    created_at: datetime | None = Field(
+        default=None, description="Snapshot creation time"
+    )
+
+
+class EvolutionTimelineResponse(BaseModel):
+    """Timeline of evolution snapshots for an archetype."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    archetype: str = Field(description="Archetype name")
+    snapshots: list[EvolutionSnapshotResponse] = Field(
+        description="Snapshots ordered by tournament date (most recent first)"
+    )
+
+
+class PredictionResponse(BaseModel):
+    """Archetype prediction for a tournament."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(description="Prediction ID")
+    archetype_id: str = Field(description="Archetype name")
+    target_tournament_id: UUID = Field(description="Target tournament ID")
+    predicted_meta_share: dict | None = Field(
+        default=None, description="Predicted meta share range {low, mid, high}"
+    )
+    predicted_day2_rate: dict | None = Field(
+        default=None, description="Predicted day 2 rate range {low, mid, high}"
+    )
+    predicted_tier: str | None = Field(
+        default=None, description="Predicted tier (S, A, B, C, Rogue)"
+    )
+    likely_adaptations: list[dict] | None = Field(
+        default=None, description="Expected adaptations"
+    )
+    confidence: float | None = Field(default=None, description="Prediction confidence")
+    methodology: str | None = Field(default=None, description="Prediction methodology")
+    actual_meta_share: float | None = Field(
+        default=None, description="Actual meta share (backfilled post-event)"
+    )
+    accuracy_score: float | None = Field(
+        default=None, description="Accuracy score (0-1, backfilled post-event)"
+    )
+    created_at: datetime | None = Field(
+        default=None, description="Prediction creation time"
+    )
+
+
+class EvolutionArticleListItem(BaseModel):
+    """Summary of an evolution article for list endpoints."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(description="Article ID")
+    archetype_id: str = Field(description="Archetype name")
+    slug: str = Field(description="URL slug")
+    title: str = Field(description="Article title")
+    excerpt: str | None = Field(default=None, description="Article excerpt")
+    status: str = Field(description="Article status (draft, review, published)")
+    is_premium: bool = Field(default=False, description="Whether article is premium")
+    published_at: datetime | None = Field(
+        default=None, description="Publication timestamp"
+    )
+
+
+class EvolutionArticleResponse(BaseModel):
+    """Full evolution article response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(description="Article ID")
+    archetype_id: str = Field(description="Archetype name")
+    slug: str = Field(description="URL slug")
+    title: str = Field(description="Article title")
+    excerpt: str | None = Field(default=None, description="Article excerpt")
+    introduction: str | None = Field(default=None, description="Article introduction")
+    conclusion: str | None = Field(default=None, description="Article conclusion")
+    status: str = Field(description="Article status")
+    is_premium: bool = Field(default=False, description="Whether article is premium")
+    published_at: datetime | None = Field(
+        default=None, description="Publication timestamp"
+    )
+    view_count: int = Field(default=0, description="View count")
+    share_count: int = Field(default=0, description="Share count")
+    snapshots: list[EvolutionSnapshotResponse] = Field(
+        default_factory=list, description="Linked snapshots"
+    )
+
+
+class PredictionAccuracyResponse(BaseModel):
+    """Prediction accuracy tracking summary."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    total_predictions: int = Field(description="Total predictions made")
+    scored_predictions: int = Field(description="Predictions with accuracy scores")
+    average_accuracy: float | None = Field(
+        default=None, description="Average accuracy score"
+    )
+    predictions: list[PredictionResponse] = Field(
+        default_factory=list, description="Recent scored predictions"
+    )

--- a/apps/api/src/schemas/pipeline.py
+++ b/apps/api/src/schemas/pipeline.py
@@ -134,3 +134,22 @@ class SyncCardsResult(BaseModel):
     cards_updated: int = Field(ge=0, description="Number of cards updated")
     errors: list[str] = Field(default_factory=list, description="Error messages")
     success: bool = Field(description="Whether sync completed without errors")
+
+
+class ComputeEvolutionRequest(PipelineRequest):
+    """Request for compute evolution pipeline."""
+
+    pass
+
+
+class ComputeEvolutionResult(BaseModel):
+    """Result from compute evolution pipeline."""
+
+    adaptations_classified: int = Field(
+        ge=0, description="Adaptations classified by Claude"
+    )
+    contexts_generated: int = Field(ge=0, description="Meta contexts generated")
+    predictions_generated: int = Field(ge=0, description="Predictions generated")
+    articles_generated: int = Field(ge=0, description="Articles generated")
+    errors: list[str] = Field(default_factory=list, description="Error messages")
+    success: bool = Field(description="Whether pipeline completed without errors")

--- a/apps/api/tests/test_compute_evolution_pipeline.py
+++ b/apps/api/tests/test_compute_evolution_pipeline.py
@@ -1,0 +1,140 @@
+"""Tests for the compute_evolution pipeline."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.models.adaptation import Adaptation
+from src.pipelines.compute_evolution import (
+    ComputeEvolutionResult,
+    compute_evolution_intelligence,
+)
+
+_UNSET = object()
+
+
+def _make_execute_result(
+    *, scalar_one_or_none=_UNSET, scalars_all=_UNSET, scalar=_UNSET, all=_UNSET
+):
+    """Create a mock result from session.execute()."""
+    mock_result = MagicMock()
+    if scalar_one_or_none is not _UNSET:
+        mock_result.scalar_one_or_none.return_value = scalar_one_or_none
+    if scalars_all is not _UNSET:
+        mock_result.scalars.return_value.all.return_value = scalars_all
+    if scalar is not _UNSET:
+        mock_result.scalar.return_value = scalar
+    if all is not _UNSET:
+        mock_result.all.return_value = all
+    return mock_result
+
+
+class TestComputeEvolutionResult:
+    """Tests for the result dataclass."""
+
+    def test_success_when_no_errors(self) -> None:
+        result = ComputeEvolutionResult()
+        assert result.success is True
+
+    def test_failure_when_errors(self) -> None:
+        result = ComputeEvolutionResult(errors=["something broke"])
+        assert result.success is False
+
+    def test_default_counts_are_zero(self) -> None:
+        result = ComputeEvolutionResult()
+        assert result.adaptations_classified == 0
+        assert result.contexts_generated == 0
+        assert result.predictions_generated == 0
+        assert result.articles_generated == 0
+
+
+class TestComputeEvolutionIntelligence:
+    """Tests for the main pipeline function."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_result(self) -> None:
+        """Should return a result without errors on dry run."""
+        mock_session = AsyncMock()
+        mock_claude = AsyncMock()
+
+        # Mock all queries to return empty results
+        mock_session.execute.return_value = _make_execute_result(scalars_all=[])
+
+        with (
+            patch("src.pipelines.compute_evolution.ClaudeClient") as mock_claude_cls,
+            patch(
+                "src.pipelines.compute_evolution.async_session_factory"
+            ) as mock_session_factory,
+        ):
+            mock_claude_cls.return_value.__aenter__ = AsyncMock(
+                return_value=mock_claude
+            )
+            mock_claude_cls.return_value.__aexit__ = AsyncMock()
+            mock_session_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session
+            )
+            mock_session_factory.return_value.__aexit__ = AsyncMock()
+
+            result = await compute_evolution_intelligence(dry_run=True)
+
+        assert isinstance(result, ComputeEvolutionResult)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_classifies_unclassified_adaptations(self) -> None:
+        """Should classify adaptations that haven't been classified by Claude."""
+        mock_session = AsyncMock()
+        mock_claude = AsyncMock()
+
+        adaptation = MagicMock(spec=Adaptation)
+        adaptation.id = uuid4()
+        adaptation.source = "diff"
+
+        # First call: unclassified adaptations, rest: empty
+        mock_session.execute.side_effect = [
+            _make_execute_result(scalars_all=[adaptation]),  # adaptations
+            _make_execute_result(scalars_all=[]),  # snapshots missing context
+            _make_execute_result(scalars_all=[]),  # upcoming tournaments
+            _make_execute_result(all=[]),  # archetypes with 3+ snapshots
+        ]
+
+        with (
+            patch("src.pipelines.compute_evolution.ClaudeClient") as mock_claude_cls,
+            patch(
+                "src.pipelines.compute_evolution.async_session_factory"
+            ) as mock_session_factory,
+            patch(
+                "src.pipelines.compute_evolution.AdaptationClassifier"
+            ) as mock_classifier_cls,
+            patch("src.pipelines.compute_evolution.PredictionEngine"),
+            patch("src.pipelines.compute_evolution.EvolutionArticleGenerator"),
+        ):
+            mock_claude_cls.return_value.__aenter__ = AsyncMock(
+                return_value=mock_claude
+            )
+            mock_claude_cls.return_value.__aexit__ = AsyncMock()
+            mock_session_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session
+            )
+            mock_session_factory.return_value.__aexit__ = AsyncMock()
+
+            mock_classifier = AsyncMock()
+            mock_classifier_cls.return_value = mock_classifier
+
+            result = await compute_evolution_intelligence(dry_run=False)
+
+        assert result.adaptations_classified == 1
+        mock_classifier.classify.assert_called_once_with(adaptation)
+
+    @pytest.mark.asyncio
+    async def test_handles_errors_gracefully(self) -> None:
+        """Should capture errors and continue processing."""
+        with patch("src.pipelines.compute_evolution.ClaudeClient") as mock_claude_cls:
+            mock_claude_cls.side_effect = Exception("Connection failed")
+
+            result = await compute_evolution_intelligence(dry_run=False)
+
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert "Connection failed" in result.errors[0]

--- a/apps/api/tests/test_evolution_router.py
+++ b/apps/api/tests/test_evolution_router.py
@@ -1,0 +1,242 @@
+"""Tests for the Evolution API router."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.models.archetype_evolution_snapshot import ArchetypeEvolutionSnapshot
+from src.models.archetype_prediction import ArchetypePrediction
+from src.models.evolution_article import EvolutionArticle
+from src.models.evolution_article_snapshot import EvolutionArticleSnapshot
+
+_UNSET = object()
+
+
+def _make_execute_result(
+    *, scalar_one_or_none=_UNSET, scalars_all=_UNSET, scalar=_UNSET
+):
+    """Create a mock result from session.execute()."""
+    mock_result = MagicMock()
+    if scalar_one_or_none is not _UNSET:
+        mock_result.scalar_one_or_none.return_value = scalar_one_or_none
+    if scalars_all is not _UNSET:
+        mock_result.scalars.return_value.all.return_value = scalars_all
+    if scalar is not _UNSET:
+        mock_result.scalar.return_value = scalar
+    return mock_result
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock database session."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def client(mock_db):
+    """Create a test client with mocked DB."""
+    from src.db.database import get_db
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+class TestGetArchetypeEvolution:
+    """Tests for GET /api/v1/archetypes/{id}/evolution."""
+
+    def test_returns_timeline(self, client, mock_db) -> None:
+        """Should return evolution timeline with snapshots."""
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.id = uuid4()
+        snapshot.archetype = "Charizard ex"
+        snapshot.tournament_id = uuid4()
+        snapshot.meta_share = 0.12
+        snapshot.top_cut_conversion = 0.35
+        snapshot.best_placement = 2
+        snapshot.deck_count = 8
+        snapshot.consensus_list = None
+        snapshot.meta_context = "Test context"
+        snapshot.adaptations = []
+        snapshot.created_at = datetime.now(UTC)
+
+        mock_db.execute.return_value = _make_execute_result(scalars_all=[snapshot])
+
+        response = client.get("/api/v1/archetypes/Charizard%20ex/evolution")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["archetype"] == "Charizard ex"
+        assert len(data["snapshots"]) == 1
+        assert data["snapshots"][0]["meta_share"] == 0.12
+
+    def test_returns_404_when_no_data(self, client, mock_db) -> None:
+        """Should return 404 when no snapshots found."""
+        mock_db.execute.return_value = _make_execute_result(scalars_all=[])
+
+        response = client.get("/api/v1/archetypes/Unknown/evolution")
+        assert response.status_code == 404
+
+
+class TestGetArchetypePrediction:
+    """Tests for GET /api/v1/archetypes/{id}/prediction."""
+
+    def test_returns_prediction(self, client, mock_db) -> None:
+        """Should return the latest prediction."""
+        prediction = MagicMock(spec=ArchetypePrediction)
+        prediction.id = uuid4()
+        prediction.archetype_id = "Charizard ex"
+        prediction.target_tournament_id = uuid4()
+        prediction.predicted_meta_share = {
+            "low": 0.08,
+            "mid": 0.12,
+            "high": 0.16,
+        }
+        prediction.predicted_day2_rate = None
+        prediction.predicted_tier = "A"
+        prediction.likely_adaptations = None
+        prediction.confidence = 0.75
+        prediction.methodology = "Based on trajectory."
+        prediction.actual_meta_share = None
+        prediction.accuracy_score = None
+        prediction.created_at = datetime.now(UTC)
+
+        mock_db.execute.return_value = _make_execute_result(
+            scalar_one_or_none=prediction
+        )
+
+        response = client.get("/api/v1/archetypes/Charizard%20ex/prediction")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["predicted_tier"] == "A"
+        assert data["confidence"] == 0.75
+
+    def test_returns_404_when_no_prediction(self, client, mock_db) -> None:
+        """Should return 404 when no prediction found."""
+        mock_db.execute.return_value = _make_execute_result(scalar_one_or_none=None)
+
+        response = client.get("/api/v1/archetypes/Unknown/prediction")
+        assert response.status_code == 404
+
+
+class TestListEvolutionArticles:
+    """Tests for GET /api/v1/evolution."""
+
+    def test_returns_article_list(self, client, mock_db) -> None:
+        """Should return list of published articles."""
+        article = MagicMock(spec=EvolutionArticle)
+        article.id = uuid4()
+        article.archetype_id = "Charizard ex"
+        article.slug = "charizard-ex-evolution-20260203"
+        article.title = "Charizard ex Evolution"
+        article.excerpt = "How Charizard adapted."
+        article.status = "published"
+        article.is_premium = False
+        article.published_at = datetime.now(UTC)
+
+        mock_db.execute.return_value = _make_execute_result(scalars_all=[article])
+
+        response = client.get("/api/v1/evolution")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["slug"] == "charizard-ex-evolution-20260203"
+
+    def test_returns_empty_list(self, client, mock_db) -> None:
+        """Should return empty list when no articles."""
+        mock_db.execute.return_value = _make_execute_result(scalars_all=[])
+
+        response = client.get("/api/v1/evolution")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestGetPredictionAccuracy:
+    """Tests for GET /api/v1/evolution/accuracy."""
+
+    def test_returns_accuracy_data(self, client, mock_db) -> None:
+        """Should return accuracy tracking summary."""
+        prediction = MagicMock(spec=ArchetypePrediction)
+        prediction.id = uuid4()
+        prediction.archetype_id = "Charizard ex"
+        prediction.target_tournament_id = uuid4()
+        prediction.predicted_meta_share = {"mid": 0.12}
+        prediction.predicted_day2_rate = None
+        prediction.predicted_tier = "A"
+        prediction.likely_adaptations = None
+        prediction.confidence = 0.8
+        prediction.methodology = "Trajectory analysis."
+        prediction.actual_meta_share = 0.11
+        prediction.accuracy_score = 0.92
+        prediction.created_at = datetime.now(UTC)
+
+        mock_db.execute.side_effect = [
+            _make_execute_result(scalar=5),  # total
+            _make_execute_result(scalar=3),  # scored
+            _make_execute_result(scalar=0.85),  # avg accuracy
+            _make_execute_result(scalars_all=[prediction]),  # predictions
+        ]
+
+        response = client.get("/api/v1/evolution/accuracy")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_predictions"] == 5
+        assert data["scored_predictions"] == 3
+        assert data["average_accuracy"] == 0.85
+        assert len(data["predictions"]) == 1
+
+
+class TestGetEvolutionArticle:
+    """Tests for GET /api/v1/evolution/{slug}."""
+
+    def test_returns_article_with_snapshots(self, client, mock_db) -> None:
+        """Should return full article with linked snapshots."""
+        snapshot = MagicMock(spec=ArchetypeEvolutionSnapshot)
+        snapshot.id = uuid4()
+        snapshot.archetype = "Charizard ex"
+        snapshot.tournament_id = uuid4()
+        snapshot.meta_share = 0.12
+        snapshot.top_cut_conversion = 0.35
+        snapshot.best_placement = 2
+        snapshot.deck_count = 8
+        snapshot.consensus_list = None
+        snapshot.meta_context = None
+        snapshot.created_at = datetime.now(UTC)
+
+        link = MagicMock(spec=EvolutionArticleSnapshot)
+        link.position = 0
+        link.snapshot = snapshot
+
+        article = MagicMock(spec=EvolutionArticle)
+        article.id = uuid4()
+        article.archetype_id = "Charizard ex"
+        article.slug = "charizard-ex-evolution-20260203"
+        article.title = "Charizard ex Evolution"
+        article.excerpt = "How it adapted."
+        article.introduction = "Intro text."
+        article.conclusion = "Conclusion text."
+        article.status = "published"
+        article.is_premium = False
+        article.published_at = datetime.now(UTC)
+        article.view_count = 10
+        article.share_count = 2
+        article.article_snapshots = [link]
+
+        mock_db.execute.return_value = _make_execute_result(scalar_one_or_none=article)
+
+        response = client.get("/api/v1/evolution/charizard-ex-evolution-20260203")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "Charizard ex Evolution"
+        assert len(data["snapshots"]) == 1
+        assert data["view_count"] == 11  # incremented
+
+    def test_returns_404_for_missing_slug(self, client, mock_db) -> None:
+        """Should return 404 for unknown slug."""
+        mock_db.execute.return_value = _make_execute_result(scalar_one_or_none=None)
+
+        response = client.get("/api/v1/evolution/nonexistent-slug")
+        assert response.status_code == 404

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -4,6 +4,7 @@
 # - discover-en: 6 AM daily (discover new EN tournaments, enqueue via Cloud Tasks)
 # - discover-jp: 7 AM daily (discover new JP tournaments, enqueue via Cloud Tasks)
 # - compute-meta: 8 AM daily (after scraping)
+# - compute-evolution: 9 AM daily (after compute-meta, AI classification + predictions)
 # - sync-cards: 3 AM Sunday weekly (low traffic)
 
 locals {
@@ -27,6 +28,13 @@ locals {
       schedule         = "0 8 * * *" # Daily at 8 AM
       uri              = "${var.cloud_run_url}/api/v1/pipeline/compute-meta"
       body             = jsonencode({ dry_run = false, lookback_days = 90 })
+      attempt_deadline = "600s"
+    }
+    compute-evolution = {
+      description      = "Run evolution intelligence (AI classification, predictions, articles)"
+      schedule         = "0 9 * * *" # Daily at 9 AM (after compute-meta at 8 AM)
+      uri              = "${var.cloud_run_url}/api/v1/pipeline/compute-evolution"
+      body             = jsonencode({ dry_run = false })
       attempt_deadline = "600s"
     }
     sync-cards = {


### PR DESCRIPTION
## Summary
- **#278**: Add `compute_evolution` pipeline orchestrating 4 AI-driven steps: adaptation classification, meta context generation, predictions, and article generation. Wired into pipeline router and Cloud Scheduler (9 AM daily).
- **#280**: Add evolution API router with 5 public endpoints: archetype evolution timeline, archetype prediction, article list, article detail (with view count increment), and prediction accuracy tracking. Add Pydantic response schemas for all evolution data.

## Changes
- `src/pipelines/compute_evolution.py` — Pipeline with `ComputeEvolutionResult` dataclass and `compute_evolution_intelligence()` function
- `src/routers/evolution.py` — 5 GET endpoints under `/api/v1/`
- `src/schemas/evolution.py` — 7 Pydantic response schemas
- `src/routers/pipeline.py` — Added `compute-evolution` pipeline endpoint
- `src/schemas/pipeline.py` — Added `ComputeEvolutionRequest` / `ComputeEvolutionResult`
- `src/routers/__init__.py` / `src/main.py` / `src/schemas/__init__.py` — Registered new router and schemas
- `terraform/modules/scheduler/main.tf` — Added `compute-evolution` scheduler job at 9 AM daily

## Test plan
- [x] 15 new tests (6 pipeline + 9 router) all passing
- [x] Full suite: 733 passed, 1 pre-existing failure (unrelated `test_shares_sum_to_one_after_filtering`)
- [x] Ruff lint + format clean
- [x] Type check (ty) passing
- [x] Pre-commit hooks all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)