### PR TITLE
feat(web): add home headline insight + trending movers

### DIFF
--- a/apps/web/src/components/home/HomePageContent.tsx
+++ b/apps/web/src/components/home/HomePageContent.tsx
@@ -9,6 +9,7 @@ import { Hero } from "./Hero";
 import { JPAlertBanner } from "./JPAlertBanner";
 import { PublicTeaserSnapshot } from "./PublicTeaserSnapshot";
 import { ResearchPassWaitlist } from "./ResearchPassWaitlist";
+import { TrendingMovers } from "./TrendingMovers";
 import { TrainersToolkit } from "./TrainersToolkit";
 import { WhyTrainerLab } from "./WhyTrainerLab";
 
@@ -54,8 +55,14 @@ export function HomePageContent() {
       </ErrorBoundary>
 
       <ErrorBoundary>
-        <Hero />
+        <Hero hasFullAccess={hasFullAccess} />
       </ErrorBoundary>
+
+      {hasFullAccess && (
+        <ErrorBoundary fallback={null}>
+          <TrendingMovers />
+        </ErrorBoundary>
+      )}
 
       {shouldRenderTeaser ? (
         <ErrorBoundary fallback={null}>
@@ -67,13 +74,13 @@ export function HomePageContent() {
             <MetaSnapshot />
           </ErrorBoundary>
           <ErrorBoundary fallback={null}>
+            <FormatForecast />
+          </ErrorBoundary>
+          <ErrorBoundary fallback={null}>
             <EvolutionPreview />
           </ErrorBoundary>
           <ErrorBoundary fallback={null}>
             <ContentGrid />
-          </ErrorBoundary>
-          <ErrorBoundary fallback={null}>
-            <FormatForecast />
           </ErrorBoundary>
         </>
       )}

--- a/apps/web/src/components/home/TrendingMovers.tsx
+++ b/apps/web/src/components/home/TrendingMovers.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+
+import { SectionLabel } from "@/components/ui/section-label";
+import { TrendArrow } from "@/components/ui/trend-arrow";
+import { useHomeMetaData } from "@/hooks/useMeta";
+import { computeMetaMovers } from "@/lib/home-utils";
+import { cn } from "@/lib/utils";
+
+export function TrendingMovers({ className }: { className?: string }) {
+  const { globalMeta, history, isLoading } = useHomeMetaData();
+
+  const movers = computeMetaMovers(globalMeta, history, 3);
+
+  if (isLoading || movers.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className={cn("container mt-10", className)}
+      data-testid="trending-movers"
+    >
+      <SectionLabel
+        label="Trending Movers"
+        variant="notebook"
+        icon={<TrendingUp className="h-4 w-4" />}
+      />
+
+      <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
+        {movers.map((mover) => (
+          <div
+            key={mover.name}
+            className="min-w-[220px] rounded-lg border border-notebook-grid bg-notebook-aged/40 px-4 py-3 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate font-display text-base font-semibold text-ink-black">
+                  {mover.name}
+                </div>
+                <div className="mt-1 font-mono text-xs uppercase tracking-wide text-pencil">
+                  {(mover.currentShare || 0).toFixed(1)}% share
+                </div>
+              </div>
+
+              <TrendArrow
+                direction={mover.changeDirection}
+                value={mover.changeValue}
+                size="sm"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/home/__tests__/TrendingMovers.test.tsx
+++ b/apps/web/src/components/home/__tests__/TrendingMovers.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TrendingMovers } from "../TrendingMovers";
+
+const mockUseHomeMetaData = vi.fn();
+
+vi.mock("@/hooks/useMeta", () => ({
+  useHomeMetaData: () => mockUseHomeMetaData(),
+}));
+
+describe("TrendingMovers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseHomeMetaData.mockReturnValue({
+      isLoading: false,
+      globalMeta: {
+        archetype_breakdown: [
+          { name: "Dragapult ex", share: 0.1 },
+          { name: "Charizard ex", share: 0.08 },
+        ],
+      },
+      history: {
+        snapshots: [
+          {
+            archetype_breakdown: [
+              { name: "Dragapult ex", share: 0.04 },
+              { name: "Charizard ex", share: 0.07 },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it("renders movers when data is available", () => {
+    render(<TrendingMovers />);
+
+    expect(screen.getByText("TRENDING MOVERS")).toBeInTheDocument();
+    expect(screen.getByText("Dragapult ex")).toBeInTheDocument();
+  });
+
+  it("renders nothing while loading", () => {
+    mockUseHomeMetaData.mockReturnValue({ isLoading: true });
+    const { container } = render(<TrendingMovers />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -4,6 +4,7 @@ export { FormatForecast } from "./FormatForecast";
 export { Hero } from "./Hero";
 export { HomePageContent } from "./HomePageContent";
 export { JPAlertBanner } from "./JPAlertBanner";
+export { TrendingMovers } from "./TrendingMovers";
 
 export { MetaSnapshot } from "./MetaSnapshot";
 export { ResearchPassWaitlist } from "./ResearchPassWaitlist";


### PR DESCRIPTION
## What
- Add `TrendingMovers` strip between the hero and the specimen sections for full-access users.
- Replace the hero paragraph (full-access only) with the biggest meta mover insight.
- Embed a next-event countdown stat into the hero stats bar.
- Reorder full-access home sections to: MetaSnapshot -> FormatForecast -> EvolutionPreview -> ContentGrid.

## Why
- Gives beta testers a high-signal “what changed” insight immediately on landing.
- Makes the homepage feel live and data-driven without altering the public teaser experience.

## How to Verify
- `source ~/.nvm/nvm.sh && nvm use default --silent && pnpm -C apps/web test`
- Logged out: homepage copy/teaser remains unchanged.
- Logged in (full access): hero paragraph shows biggest mover + `TrendingMovers` renders.

## Review Focus
- Access gating: public home unchanged; full-access home shows new strip.
- No extra network calls beyond existing home meta queries (React Query dedupe).
- UI layout stability (no jarring shifts while meta loads).

Closes #374.