### PR TITLE
chore(docs): add Tool Radar to scraper architecture

### DIFF
--- a/docs/SCRAPER_ARCHITECTURE.md
+++ b/docs/SCRAPER_ARCHITECTURE.md
@@ -202,3 +202,11 @@ erDiagram
 
 The EN pipeline's official scraper maps country codes to regions via `_country_to_region()`.
 JP tournaments are always BO1 (ties = double loss).
+
+## Tool Radar
+
+Tools evaluated for potential adoption. Not currently in use.
+
+| Tool                               | What It Does                                                                                                                                                                                            | When to Revisit                                                                         | Evaluated  |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------- |
+| [Kernel.sh](https://www.kernel.sh) | Browsers-as-a-Service (cloud headless browsers via CDP). Headless at $0.06/hr, free tier includes $5/mo credits and 5 concurrent sessions. Supports Playwright/Puppeteer, residential proxies included. | If target sites add JS rendering, Cloudflare/bot protection, or we need to scrape SPAs. | 2026-02-22 |


### PR DESCRIPTION
## Summary
- Add "Tool Radar" section to `docs/SCRAPER_ARCHITECTURE.md`
- Log Kernel.sh (Browsers-as-a-Service) evaluation — not needed now since all targets serve static HTML via httpx+BS4, but worth revisiting if sites add JS rendering or bot protection

## Test plan
- [x] Markdown renders correctly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)